### PR TITLE
Added additional window hints for x11 to create bg windows

### DIFF
--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -30,9 +30,9 @@
 #define _glfw3_h_
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
-
 
 /*************************************************************************
  * Doxygen documentation
@@ -85,7 +85,6 @@ extern "C" {
  *  information, see the @ref window_guide.
  */
 
-
 /*************************************************************************
  * Compiler- and platform-specific preprocessor work
  *************************************************************************/
@@ -93,7 +92,7 @@ extern "C" {
 /* If we are we on Windows, we want a single define for it.
  */
 #if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__MINGW32__))
- #define _WIN32
+#define _WIN32
 #endif /* _WIN32 */
 
 /* Include because most Windows GLU headers need wchar_t and
@@ -108,7 +107,7 @@ extern "C" {
 #include <stdint.h>
 
 #if defined(GLFW_INCLUDE_VULKAN)
-  #include <vulkan/vulkan.h>
+#include <vulkan/vulkan.h>
 #endif /* Vulkan header */
 
 /* The Vulkan header may have indirectly included windows.h (because of
@@ -119,156 +118,155 @@ extern "C" {
  * all platforms.  Additionally, the Windows OpenGL header needs APIENTRY.
  */
 #if !defined(APIENTRY)
- #if defined(_WIN32)
-  #define APIENTRY __stdcall
- #else
-  #define APIENTRY
- #endif
- #define GLFW_APIENTRY_DEFINED
+#if defined(_WIN32)
+#define APIENTRY __stdcall
+#else
+#define APIENTRY
+#endif
+#define GLFW_APIENTRY_DEFINED
 #endif /* APIENTRY */
 
 /* Some Windows OpenGL headers need this.
  */
 #if !defined(WINGDIAPI) && defined(_WIN32)
- #define WINGDIAPI __declspec(dllimport)
- #define GLFW_WINGDIAPI_DEFINED
+#define WINGDIAPI __declspec(dllimport)
+#define GLFW_WINGDIAPI_DEFINED
 #endif /* WINGDIAPI */
 
 /* Some Windows GLU headers need this.
  */
 #if !defined(CALLBACK) && defined(_WIN32)
- #define CALLBACK __stdcall
- #define GLFW_CALLBACK_DEFINED
+#define CALLBACK __stdcall
+#define GLFW_CALLBACK_DEFINED
 #endif /* CALLBACK */
 
 /* Include the chosen OpenGL or OpenGL ES headers.
  */
 #if defined(GLFW_INCLUDE_ES1)
 
- #include <GLES/gl.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES/glext.h>
- #endif
+#include <GLES/gl.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES/glext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES2)
 
- #include <GLES2/gl2.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES2/gl2.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES3)
 
- #include <GLES3/gl3.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES3/gl3.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES31)
 
- #include <GLES3/gl31.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES3/gl31.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_ES32)
 
- #include <GLES3/gl32.h>
- #if defined(GLFW_INCLUDE_GLEXT)
-  #include <GLES2/gl2ext.h>
- #endif
+#include <GLES3/gl32.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GLES2/gl2ext.h>
+#endif
 
 #elif defined(GLFW_INCLUDE_GLCOREARB)
 
- #if defined(__APPLE__)
+#if defined(__APPLE__)
 
-  #include <OpenGL/gl3.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <OpenGL/gl3ext.h>
-  #endif /*GLFW_INCLUDE_GLEXT*/
+#include <OpenGL/gl3.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <OpenGL/gl3ext.h>
+#endif /*GLFW_INCLUDE_GLEXT*/
 
- #else /*__APPLE__*/
+#else /*__APPLE__*/
 
-  #include <GL/glcorearb.h>
+#include <GL/glcorearb.h>
 
- #endif /*__APPLE__*/
+#endif /*__APPLE__*/
 
 #elif defined(GLFW_INCLUDE_GLU)
 
- #if defined(__APPLE__)
+#if defined(__APPLE__)
 
-  #if defined(GLFW_INCLUDE_GLU)
-   #include <OpenGL/glu.h>
-  #endif
+#if defined(GLFW_INCLUDE_GLU)
+#include <OpenGL/glu.h>
+#endif
 
- #else /*__APPLE__*/
+#else /*__APPLE__*/
 
-  #if defined(GLFW_INCLUDE_GLU)
-   #include <GL/glu.h>
-  #endif
+#if defined(GLFW_INCLUDE_GLU)
+#include <GL/glu.h>
+#endif
 
- #endif /*__APPLE__*/
+#endif /*__APPLE__*/
 
-#elif !defined(GLFW_INCLUDE_NONE) && \
-      !defined(__gl_h_) && \
-      !defined(__gles1_gl_h_) && \
-      !defined(__gles2_gl2_h_) && \
-      !defined(__gles2_gl3_h_) && \
-      !defined(__gles2_gl31_h_) && \
-      !defined(__gles2_gl32_h_) && \
-      !defined(__gl_glcorearb_h_) && \
-      !defined(__gl2_h_) /*legacy*/ && \
-      !defined(__gl3_h_) /*legacy*/ && \
-      !defined(__gl31_h_) /*legacy*/ && \
-      !defined(__gl32_h_) /*legacy*/ && \
-      !defined(__glcorearb_h_) /*legacy*/ && \
-      !defined(__GL_H__) /*non-standard*/ && \
-      !defined(__gltypes_h_) /*non-standard*/ && \
-      !defined(__glee_h_) /*non-standard*/
+#elif !defined(GLFW_INCLUDE_NONE) &&           \
+    !defined(__gl_h_) &&                       \
+    !defined(__gles1_gl_h_) &&                 \
+    !defined(__gles2_gl2_h_) &&                \
+    !defined(__gles2_gl3_h_) &&                \
+    !defined(__gles2_gl31_h_) &&               \
+    !defined(__gles2_gl32_h_) &&               \
+    !defined(__gl_glcorearb_h_) &&             \
+    !defined(__gl2_h_) /*legacy*/ &&           \
+    !defined(__gl3_h_) /*legacy*/ &&           \
+    !defined(__gl31_h_) /*legacy*/ &&          \
+    !defined(__gl32_h_) /*legacy*/ &&          \
+    !defined(__glcorearb_h_) /*legacy*/ &&     \
+    !defined(__GL_H__) /*non-standard*/ &&     \
+    !defined(__gltypes_h_) /*non-standard*/ && \
+    !defined(__glee_h_) /*non-standard*/
 
- #if defined(__APPLE__)
+#if defined(__APPLE__)
 
-  #if !defined(GLFW_INCLUDE_GLEXT)
-   #define GL_GLEXT_LEGACY
-  #endif
-  #include <OpenGL/gl.h>
+#if !defined(GLFW_INCLUDE_GLEXT)
+#define GL_GLEXT_LEGACY
+#endif
+#include <OpenGL/gl.h>
 
- #else /*__APPLE__*/
+#else /*__APPLE__*/
 
-  #include <GL/gl.h>
-  #if defined(GLFW_INCLUDE_GLEXT)
-   #include <GL/glext.h>
-  #endif
+#include <GL/gl.h>
+#if defined(GLFW_INCLUDE_GLEXT)
+#include <GL/glext.h>
+#endif
 
- #endif /*__APPLE__*/
+#endif /*__APPLE__*/
 
 #endif /* OpenGL and OpenGL ES headers */
 
 #if defined(GLFW_DLL) && defined(_GLFW_BUILD_DLL)
- /* GLFW_DLL must be defined by applications that are linking against the DLL
-  * version of the GLFW library.  _GLFW_BUILD_DLL is defined by the GLFW
-  * configuration header when compiling the DLL version of the library.
-  */
- #error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
+/* GLFW_DLL must be defined by applications that are linking against the DLL
+ * version of the GLFW library.  _GLFW_BUILD_DLL is defined by the GLFW
+ * configuration header when compiling the DLL version of the library.
+ */
+#error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
 #endif
 
 /* GLFWAPI is used to declare public API functions for export
  * from the DLL / shared library / dynamic library.
  */
 #if defined(_WIN32) && defined(_GLFW_BUILD_DLL)
- /* We are building GLFW as a Win32 DLL */
- #define GLFWAPI __declspec(dllexport)
+/* We are building GLFW as a Win32 DLL */
+#define GLFWAPI __declspec(dllexport)
 #elif defined(_WIN32) && defined(GLFW_DLL)
- /* We are calling GLFW as a Win32 DLL */
- #define GLFWAPI __declspec(dllimport)
+/* We are calling GLFW as a Win32 DLL */
+#define GLFWAPI __declspec(dllimport)
 #elif defined(__GNUC__) && defined(_GLFW_BUILD_DLL)
- /* We are building GLFW as a shared / dynamic library */
- #define GLFWAPI __attribute__((visibility("default")))
+/* We are building GLFW as a shared / dynamic library */
+#define GLFWAPI __attribute__((visibility("default")))
 #else
- /* We are building or calling GLFW as a static library */
- #define GLFWAPI
+/* We are building or calling GLFW as a static library */
+#define GLFWAPI
 #endif
-
 
 /*************************************************************************
  * GLFW API tokens
@@ -282,21 +280,21 @@ extern "C" {
  *  API is changed in non-compatible ways.
  *  @ingroup init
  */
-#define GLFW_VERSION_MAJOR          3
+#define GLFW_VERSION_MAJOR 3
 /*! @brief The minor version number of the GLFW header.
  *
  *  The minor version number of the GLFW header.  This is incremented when
  *  features are added to the API but it remains backward-compatible.
  *  @ingroup init
  */
-#define GLFW_VERSION_MINOR          4
+#define GLFW_VERSION_MINOR 4
 /*! @brief The revision number of the GLFW header.
  *
  *  The revision number of the GLFW header.  This is incremented when a bug fix
  *  release is made that does not contain any API changes.
  *  @ingroup init
  */
-#define GLFW_VERSION_REVISION       0
+#define GLFW_VERSION_REVISION 0
 /*! @} */
 
 /*! @brief One.
@@ -307,7 +305,7 @@ extern "C" {
  *
  *  @ingroup init
  */
-#define GLFW_TRUE                   1
+#define GLFW_TRUE 1
 /*! @brief Zero.
  *
  *  This is only semantic sugar for the number 0.  You can instead use `0` or
@@ -316,7 +314,7 @@ extern "C" {
  *
  *  @ingroup init
  */
-#define GLFW_FALSE                  0
+#define GLFW_FALSE 0
 
 /*! @name Key and button actions
  *  @{ */
@@ -326,21 +324,21 @@ extern "C" {
  *
  *  @ingroup input
  */
-#define GLFW_RELEASE                0
+#define GLFW_RELEASE 0
 /*! @brief The key or mouse button was pressed.
  *
  *  The key or mouse button was pressed.
  *
  *  @ingroup input
  */
-#define GLFW_PRESS                  1
+#define GLFW_PRESS 1
 /*! @brief The key was held down until it repeated.
  *
  *  The key was held down until it repeated.
  *
  *  @ingroup input
  */
-#define GLFW_REPEAT                 2
+#define GLFW_REPEAT 2
 /*! @} */
 
 /*! @defgroup hat_state Joystick hat states
@@ -350,15 +348,15 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_HAT_CENTERED           0
-#define GLFW_HAT_UP                 1
-#define GLFW_HAT_RIGHT              2
-#define GLFW_HAT_DOWN               4
-#define GLFW_HAT_LEFT               8
-#define GLFW_HAT_RIGHT_UP           (GLFW_HAT_RIGHT | GLFW_HAT_UP)
-#define GLFW_HAT_RIGHT_DOWN         (GLFW_HAT_RIGHT | GLFW_HAT_DOWN)
-#define GLFW_HAT_LEFT_UP            (GLFW_HAT_LEFT  | GLFW_HAT_UP)
-#define GLFW_HAT_LEFT_DOWN          (GLFW_HAT_LEFT  | GLFW_HAT_DOWN)
+#define GLFW_HAT_CENTERED 0
+#define GLFW_HAT_UP 1
+#define GLFW_HAT_RIGHT 2
+#define GLFW_HAT_DOWN 4
+#define GLFW_HAT_LEFT 8
+#define GLFW_HAT_RIGHT_UP (GLFW_HAT_RIGHT | GLFW_HAT_UP)
+#define GLFW_HAT_RIGHT_DOWN (GLFW_HAT_RIGHT | GLFW_HAT_DOWN)
+#define GLFW_HAT_LEFT_UP (GLFW_HAT_LEFT | GLFW_HAT_UP)
+#define GLFW_HAT_LEFT_DOWN (GLFW_HAT_LEFT | GLFW_HAT_DOWN)
 /*! @} */
 
 /*! @defgroup keys Keyboard keys
@@ -386,133 +384,133 @@ extern "C" {
  */
 
 /* The unknown key */
-#define GLFW_KEY_UNKNOWN            -1
+#define GLFW_KEY_UNKNOWN -1
 
 /* Printable keys */
-#define GLFW_KEY_SPACE              32
-#define GLFW_KEY_APOSTROPHE         39  /* ' */
-#define GLFW_KEY_COMMA              44  /* , */
-#define GLFW_KEY_MINUS              45  /* - */
-#define GLFW_KEY_PERIOD             46  /* . */
-#define GLFW_KEY_SLASH              47  /* / */
-#define GLFW_KEY_0                  48
-#define GLFW_KEY_1                  49
-#define GLFW_KEY_2                  50
-#define GLFW_KEY_3                  51
-#define GLFW_KEY_4                  52
-#define GLFW_KEY_5                  53
-#define GLFW_KEY_6                  54
-#define GLFW_KEY_7                  55
-#define GLFW_KEY_8                  56
-#define GLFW_KEY_9                  57
-#define GLFW_KEY_SEMICOLON          59  /* ; */
-#define GLFW_KEY_EQUAL              61  /* = */
-#define GLFW_KEY_A                  65
-#define GLFW_KEY_B                  66
-#define GLFW_KEY_C                  67
-#define GLFW_KEY_D                  68
-#define GLFW_KEY_E                  69
-#define GLFW_KEY_F                  70
-#define GLFW_KEY_G                  71
-#define GLFW_KEY_H                  72
-#define GLFW_KEY_I                  73
-#define GLFW_KEY_J                  74
-#define GLFW_KEY_K                  75
-#define GLFW_KEY_L                  76
-#define GLFW_KEY_M                  77
-#define GLFW_KEY_N                  78
-#define GLFW_KEY_O                  79
-#define GLFW_KEY_P                  80
-#define GLFW_KEY_Q                  81
-#define GLFW_KEY_R                  82
-#define GLFW_KEY_S                  83
-#define GLFW_KEY_T                  84
-#define GLFW_KEY_U                  85
-#define GLFW_KEY_V                  86
-#define GLFW_KEY_W                  87
-#define GLFW_KEY_X                  88
-#define GLFW_KEY_Y                  89
-#define GLFW_KEY_Z                  90
-#define GLFW_KEY_LEFT_BRACKET       91  /* [ */
-#define GLFW_KEY_BACKSLASH          92  /* \ */
-#define GLFW_KEY_RIGHT_BRACKET      93  /* ] */
-#define GLFW_KEY_GRAVE_ACCENT       96  /* ` */
-#define GLFW_KEY_WORLD_1            161 /* non-US #1 */
-#define GLFW_KEY_WORLD_2            162 /* non-US #2 */
+#define GLFW_KEY_SPACE 32
+#define GLFW_KEY_APOSTROPHE 39 /* ' */
+#define GLFW_KEY_COMMA 44      /* , */
+#define GLFW_KEY_MINUS 45      /* - */
+#define GLFW_KEY_PERIOD 46     /* . */
+#define GLFW_KEY_SLASH 47      /* / */
+#define GLFW_KEY_0 48
+#define GLFW_KEY_1 49
+#define GLFW_KEY_2 50
+#define GLFW_KEY_3 51
+#define GLFW_KEY_4 52
+#define GLFW_KEY_5 53
+#define GLFW_KEY_6 54
+#define GLFW_KEY_7 55
+#define GLFW_KEY_8 56
+#define GLFW_KEY_9 57
+#define GLFW_KEY_SEMICOLON 59 /* ; */
+#define GLFW_KEY_EQUAL 61     /* = */
+#define GLFW_KEY_A 65
+#define GLFW_KEY_B 66
+#define GLFW_KEY_C 67
+#define GLFW_KEY_D 68
+#define GLFW_KEY_E 69
+#define GLFW_KEY_F 70
+#define GLFW_KEY_G 71
+#define GLFW_KEY_H 72
+#define GLFW_KEY_I 73
+#define GLFW_KEY_J 74
+#define GLFW_KEY_K 75
+#define GLFW_KEY_L 76
+#define GLFW_KEY_M 77
+#define GLFW_KEY_N 78
+#define GLFW_KEY_O 79
+#define GLFW_KEY_P 80
+#define GLFW_KEY_Q 81
+#define GLFW_KEY_R 82
+#define GLFW_KEY_S 83
+#define GLFW_KEY_T 84
+#define GLFW_KEY_U 85
+#define GLFW_KEY_V 86
+#define GLFW_KEY_W 87
+#define GLFW_KEY_X 88
+#define GLFW_KEY_Y 89
+#define GLFW_KEY_Z 90
+#define GLFW_KEY_LEFT_BRACKET 91  /* [ */
+#define GLFW_KEY_BACKSLASH 92     /* \ */
+#define GLFW_KEY_RIGHT_BRACKET 93 /* ] */
+#define GLFW_KEY_GRAVE_ACCENT 96  /* ` */
+#define GLFW_KEY_WORLD_1 161      /* non-US #1 */
+#define GLFW_KEY_WORLD_2 162      /* non-US #2 */
 
 /* Function keys */
-#define GLFW_KEY_ESCAPE             256
-#define GLFW_KEY_ENTER              257
-#define GLFW_KEY_TAB                258
-#define GLFW_KEY_BACKSPACE          259
-#define GLFW_KEY_INSERT             260
-#define GLFW_KEY_DELETE             261
-#define GLFW_KEY_RIGHT              262
-#define GLFW_KEY_LEFT               263
-#define GLFW_KEY_DOWN               264
-#define GLFW_KEY_UP                 265
-#define GLFW_KEY_PAGE_UP            266
-#define GLFW_KEY_PAGE_DOWN          267
-#define GLFW_KEY_HOME               268
-#define GLFW_KEY_END                269
-#define GLFW_KEY_CAPS_LOCK          280
-#define GLFW_KEY_SCROLL_LOCK        281
-#define GLFW_KEY_NUM_LOCK           282
-#define GLFW_KEY_PRINT_SCREEN       283
-#define GLFW_KEY_PAUSE              284
-#define GLFW_KEY_F1                 290
-#define GLFW_KEY_F2                 291
-#define GLFW_KEY_F3                 292
-#define GLFW_KEY_F4                 293
-#define GLFW_KEY_F5                 294
-#define GLFW_KEY_F6                 295
-#define GLFW_KEY_F7                 296
-#define GLFW_KEY_F8                 297
-#define GLFW_KEY_F9                 298
-#define GLFW_KEY_F10                299
-#define GLFW_KEY_F11                300
-#define GLFW_KEY_F12                301
-#define GLFW_KEY_F13                302
-#define GLFW_KEY_F14                303
-#define GLFW_KEY_F15                304
-#define GLFW_KEY_F16                305
-#define GLFW_KEY_F17                306
-#define GLFW_KEY_F18                307
-#define GLFW_KEY_F19                308
-#define GLFW_KEY_F20                309
-#define GLFW_KEY_F21                310
-#define GLFW_KEY_F22                311
-#define GLFW_KEY_F23                312
-#define GLFW_KEY_F24                313
-#define GLFW_KEY_F25                314
-#define GLFW_KEY_KP_0               320
-#define GLFW_KEY_KP_1               321
-#define GLFW_KEY_KP_2               322
-#define GLFW_KEY_KP_3               323
-#define GLFW_KEY_KP_4               324
-#define GLFW_KEY_KP_5               325
-#define GLFW_KEY_KP_6               326
-#define GLFW_KEY_KP_7               327
-#define GLFW_KEY_KP_8               328
-#define GLFW_KEY_KP_9               329
-#define GLFW_KEY_KP_DECIMAL         330
-#define GLFW_KEY_KP_DIVIDE          331
-#define GLFW_KEY_KP_MULTIPLY        332
-#define GLFW_KEY_KP_SUBTRACT        333
-#define GLFW_KEY_KP_ADD             334
-#define GLFW_KEY_KP_ENTER           335
-#define GLFW_KEY_KP_EQUAL           336
-#define GLFW_KEY_LEFT_SHIFT         340
-#define GLFW_KEY_LEFT_CONTROL       341
-#define GLFW_KEY_LEFT_ALT           342
-#define GLFW_KEY_LEFT_SUPER         343
-#define GLFW_KEY_RIGHT_SHIFT        344
-#define GLFW_KEY_RIGHT_CONTROL      345
-#define GLFW_KEY_RIGHT_ALT          346
-#define GLFW_KEY_RIGHT_SUPER        347
-#define GLFW_KEY_MENU               348
+#define GLFW_KEY_ESCAPE 256
+#define GLFW_KEY_ENTER 257
+#define GLFW_KEY_TAB 258
+#define GLFW_KEY_BACKSPACE 259
+#define GLFW_KEY_INSERT 260
+#define GLFW_KEY_DELETE 261
+#define GLFW_KEY_RIGHT 262
+#define GLFW_KEY_LEFT 263
+#define GLFW_KEY_DOWN 264
+#define GLFW_KEY_UP 265
+#define GLFW_KEY_PAGE_UP 266
+#define GLFW_KEY_PAGE_DOWN 267
+#define GLFW_KEY_HOME 268
+#define GLFW_KEY_END 269
+#define GLFW_KEY_CAPS_LOCK 280
+#define GLFW_KEY_SCROLL_LOCK 281
+#define GLFW_KEY_NUM_LOCK 282
+#define GLFW_KEY_PRINT_SCREEN 283
+#define GLFW_KEY_PAUSE 284
+#define GLFW_KEY_F1 290
+#define GLFW_KEY_F2 291
+#define GLFW_KEY_F3 292
+#define GLFW_KEY_F4 293
+#define GLFW_KEY_F5 294
+#define GLFW_KEY_F6 295
+#define GLFW_KEY_F7 296
+#define GLFW_KEY_F8 297
+#define GLFW_KEY_F9 298
+#define GLFW_KEY_F10 299
+#define GLFW_KEY_F11 300
+#define GLFW_KEY_F12 301
+#define GLFW_KEY_F13 302
+#define GLFW_KEY_F14 303
+#define GLFW_KEY_F15 304
+#define GLFW_KEY_F16 305
+#define GLFW_KEY_F17 306
+#define GLFW_KEY_F18 307
+#define GLFW_KEY_F19 308
+#define GLFW_KEY_F20 309
+#define GLFW_KEY_F21 310
+#define GLFW_KEY_F22 311
+#define GLFW_KEY_F23 312
+#define GLFW_KEY_F24 313
+#define GLFW_KEY_F25 314
+#define GLFW_KEY_KP_0 320
+#define GLFW_KEY_KP_1 321
+#define GLFW_KEY_KP_2 322
+#define GLFW_KEY_KP_3 323
+#define GLFW_KEY_KP_4 324
+#define GLFW_KEY_KP_5 325
+#define GLFW_KEY_KP_6 326
+#define GLFW_KEY_KP_7 327
+#define GLFW_KEY_KP_8 328
+#define GLFW_KEY_KP_9 329
+#define GLFW_KEY_KP_DECIMAL 330
+#define GLFW_KEY_KP_DIVIDE 331
+#define GLFW_KEY_KP_MULTIPLY 332
+#define GLFW_KEY_KP_SUBTRACT 333
+#define GLFW_KEY_KP_ADD 334
+#define GLFW_KEY_KP_ENTER 335
+#define GLFW_KEY_KP_EQUAL 336
+#define GLFW_KEY_LEFT_SHIFT 340
+#define GLFW_KEY_LEFT_CONTROL 341
+#define GLFW_KEY_LEFT_ALT 342
+#define GLFW_KEY_LEFT_SUPER 343
+#define GLFW_KEY_RIGHT_SHIFT 344
+#define GLFW_KEY_RIGHT_CONTROL 345
+#define GLFW_KEY_RIGHT_ALT 346
+#define GLFW_KEY_RIGHT_SUPER 347
+#define GLFW_KEY_MENU 348
 
-#define GLFW_KEY_LAST               GLFW_KEY_MENU
+#define GLFW_KEY_LAST GLFW_KEY_MENU
 
 /*! @} */
 
@@ -528,34 +526,34 @@ extern "C" {
  *
  *  If this bit is set one or more Shift keys were held down.
  */
-#define GLFW_MOD_SHIFT           0x0001
+#define GLFW_MOD_SHIFT 0x0001
 /*! @brief If this bit is set one or more Control keys were held down.
  *
  *  If this bit is set one or more Control keys were held down.
  */
-#define GLFW_MOD_CONTROL         0x0002
+#define GLFW_MOD_CONTROL 0x0002
 /*! @brief If this bit is set one or more Alt keys were held down.
  *
  *  If this bit is set one or more Alt keys were held down.
  */
-#define GLFW_MOD_ALT             0x0004
+#define GLFW_MOD_ALT 0x0004
 /*! @brief If this bit is set one or more Super keys were held down.
  *
  *  If this bit is set one or more Super keys were held down.
  */
-#define GLFW_MOD_SUPER           0x0008
+#define GLFW_MOD_SUPER 0x0008
 /*! @brief If this bit is set the Caps Lock key is enabled.
  *
  *  If this bit is set the Caps Lock key is enabled and the @ref
  *  GLFW_LOCK_KEY_MODS input mode is set.
  */
-#define GLFW_MOD_CAPS_LOCK       0x0010
+#define GLFW_MOD_CAPS_LOCK 0x0010
 /*! @brief If this bit is set the Num Lock key is enabled.
  *
  *  If this bit is set the Num Lock key is enabled and the @ref
  *  GLFW_LOCK_KEY_MODS input mode is set.
  */
-#define GLFW_MOD_NUM_LOCK        0x0020
+#define GLFW_MOD_NUM_LOCK 0x0020
 
 /*! @} */
 
@@ -566,18 +564,18 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_MOUSE_BUTTON_1         0
-#define GLFW_MOUSE_BUTTON_2         1
-#define GLFW_MOUSE_BUTTON_3         2
-#define GLFW_MOUSE_BUTTON_4         3
-#define GLFW_MOUSE_BUTTON_5         4
-#define GLFW_MOUSE_BUTTON_6         5
-#define GLFW_MOUSE_BUTTON_7         6
-#define GLFW_MOUSE_BUTTON_8         7
-#define GLFW_MOUSE_BUTTON_LAST      GLFW_MOUSE_BUTTON_8
-#define GLFW_MOUSE_BUTTON_LEFT      GLFW_MOUSE_BUTTON_1
-#define GLFW_MOUSE_BUTTON_RIGHT     GLFW_MOUSE_BUTTON_2
-#define GLFW_MOUSE_BUTTON_MIDDLE    GLFW_MOUSE_BUTTON_3
+#define GLFW_MOUSE_BUTTON_1 0
+#define GLFW_MOUSE_BUTTON_2 1
+#define GLFW_MOUSE_BUTTON_3 2
+#define GLFW_MOUSE_BUTTON_4 3
+#define GLFW_MOUSE_BUTTON_5 4
+#define GLFW_MOUSE_BUTTON_6 5
+#define GLFW_MOUSE_BUTTON_7 6
+#define GLFW_MOUSE_BUTTON_8 7
+#define GLFW_MOUSE_BUTTON_LAST GLFW_MOUSE_BUTTON_8
+#define GLFW_MOUSE_BUTTON_LEFT GLFW_MOUSE_BUTTON_1
+#define GLFW_MOUSE_BUTTON_RIGHT GLFW_MOUSE_BUTTON_2
+#define GLFW_MOUSE_BUTTON_MIDDLE GLFW_MOUSE_BUTTON_3
 /*! @} */
 
 /*! @defgroup joysticks Joysticks
@@ -587,23 +585,23 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_JOYSTICK_1             0
-#define GLFW_JOYSTICK_2             1
-#define GLFW_JOYSTICK_3             2
-#define GLFW_JOYSTICK_4             3
-#define GLFW_JOYSTICK_5             4
-#define GLFW_JOYSTICK_6             5
-#define GLFW_JOYSTICK_7             6
-#define GLFW_JOYSTICK_8             7
-#define GLFW_JOYSTICK_9             8
-#define GLFW_JOYSTICK_10            9
-#define GLFW_JOYSTICK_11            10
-#define GLFW_JOYSTICK_12            11
-#define GLFW_JOYSTICK_13            12
-#define GLFW_JOYSTICK_14            13
-#define GLFW_JOYSTICK_15            14
-#define GLFW_JOYSTICK_16            15
-#define GLFW_JOYSTICK_LAST          GLFW_JOYSTICK_16
+#define GLFW_JOYSTICK_1 0
+#define GLFW_JOYSTICK_2 1
+#define GLFW_JOYSTICK_3 2
+#define GLFW_JOYSTICK_4 3
+#define GLFW_JOYSTICK_5 4
+#define GLFW_JOYSTICK_6 5
+#define GLFW_JOYSTICK_7 6
+#define GLFW_JOYSTICK_8 7
+#define GLFW_JOYSTICK_9 8
+#define GLFW_JOYSTICK_10 9
+#define GLFW_JOYSTICK_11 10
+#define GLFW_JOYSTICK_12 11
+#define GLFW_JOYSTICK_13 12
+#define GLFW_JOYSTICK_14 13
+#define GLFW_JOYSTICK_15 14
+#define GLFW_JOYSTICK_16 15
+#define GLFW_JOYSTICK_LAST GLFW_JOYSTICK_16
 /*! @} */
 
 /*! @defgroup gamepad_buttons Gamepad buttons
@@ -613,27 +611,27 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_GAMEPAD_BUTTON_A               0
-#define GLFW_GAMEPAD_BUTTON_B               1
-#define GLFW_GAMEPAD_BUTTON_X               2
-#define GLFW_GAMEPAD_BUTTON_Y               3
-#define GLFW_GAMEPAD_BUTTON_LEFT_BUMPER     4
-#define GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER    5
-#define GLFW_GAMEPAD_BUTTON_BACK            6
-#define GLFW_GAMEPAD_BUTTON_START           7
-#define GLFW_GAMEPAD_BUTTON_GUIDE           8
-#define GLFW_GAMEPAD_BUTTON_LEFT_THUMB      9
-#define GLFW_GAMEPAD_BUTTON_RIGHT_THUMB     10
-#define GLFW_GAMEPAD_BUTTON_DPAD_UP         11
-#define GLFW_GAMEPAD_BUTTON_DPAD_RIGHT      12
-#define GLFW_GAMEPAD_BUTTON_DPAD_DOWN       13
-#define GLFW_GAMEPAD_BUTTON_DPAD_LEFT       14
-#define GLFW_GAMEPAD_BUTTON_LAST            GLFW_GAMEPAD_BUTTON_DPAD_LEFT
+#define GLFW_GAMEPAD_BUTTON_A 0
+#define GLFW_GAMEPAD_BUTTON_B 1
+#define GLFW_GAMEPAD_BUTTON_X 2
+#define GLFW_GAMEPAD_BUTTON_Y 3
+#define GLFW_GAMEPAD_BUTTON_LEFT_BUMPER 4
+#define GLFW_GAMEPAD_BUTTON_RIGHT_BUMPER 5
+#define GLFW_GAMEPAD_BUTTON_BACK 6
+#define GLFW_GAMEPAD_BUTTON_START 7
+#define GLFW_GAMEPAD_BUTTON_GUIDE 8
+#define GLFW_GAMEPAD_BUTTON_LEFT_THUMB 9
+#define GLFW_GAMEPAD_BUTTON_RIGHT_THUMB 10
+#define GLFW_GAMEPAD_BUTTON_DPAD_UP 11
+#define GLFW_GAMEPAD_BUTTON_DPAD_RIGHT 12
+#define GLFW_GAMEPAD_BUTTON_DPAD_DOWN 13
+#define GLFW_GAMEPAD_BUTTON_DPAD_LEFT 14
+#define GLFW_GAMEPAD_BUTTON_LAST GLFW_GAMEPAD_BUTTON_DPAD_LEFT
 
-#define GLFW_GAMEPAD_BUTTON_CROSS       GLFW_GAMEPAD_BUTTON_A
-#define GLFW_GAMEPAD_BUTTON_CIRCLE      GLFW_GAMEPAD_BUTTON_B
-#define GLFW_GAMEPAD_BUTTON_SQUARE      GLFW_GAMEPAD_BUTTON_X
-#define GLFW_GAMEPAD_BUTTON_TRIANGLE    GLFW_GAMEPAD_BUTTON_Y
+#define GLFW_GAMEPAD_BUTTON_CROSS GLFW_GAMEPAD_BUTTON_A
+#define GLFW_GAMEPAD_BUTTON_CIRCLE GLFW_GAMEPAD_BUTTON_B
+#define GLFW_GAMEPAD_BUTTON_SQUARE GLFW_GAMEPAD_BUTTON_X
+#define GLFW_GAMEPAD_BUTTON_TRIANGLE GLFW_GAMEPAD_BUTTON_Y
 /*! @} */
 
 /*! @defgroup gamepad_axes Gamepad axes
@@ -643,13 +641,13 @@ extern "C" {
  *
  *  @ingroup input
  *  @{ */
-#define GLFW_GAMEPAD_AXIS_LEFT_X        0
-#define GLFW_GAMEPAD_AXIS_LEFT_Y        1
-#define GLFW_GAMEPAD_AXIS_RIGHT_X       2
-#define GLFW_GAMEPAD_AXIS_RIGHT_Y       3
-#define GLFW_GAMEPAD_AXIS_LEFT_TRIGGER  4
+#define GLFW_GAMEPAD_AXIS_LEFT_X 0
+#define GLFW_GAMEPAD_AXIS_LEFT_Y 1
+#define GLFW_GAMEPAD_AXIS_RIGHT_X 2
+#define GLFW_GAMEPAD_AXIS_RIGHT_Y 3
+#define GLFW_GAMEPAD_AXIS_LEFT_TRIGGER 4
 #define GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER 5
-#define GLFW_GAMEPAD_AXIS_LAST          GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER
+#define GLFW_GAMEPAD_AXIS_LAST GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER
 /*! @} */
 
 /*! @defgroup errors Error codes
@@ -665,7 +663,7 @@ extern "C" {
  *
  *  @analysis Yay.
  */
-#define GLFW_NO_ERROR               0
+#define GLFW_NO_ERROR 0
 /*! @brief GLFW has not been initialized.
  *
  *  This occurs if a GLFW function was called that must not be called unless the
@@ -674,7 +672,7 @@ extern "C" {
  *  @analysis Application programmer error.  Initialize GLFW before calling any
  *  function that requires initialization.
  */
-#define GLFW_NOT_INITIALIZED        0x00010001
+#define GLFW_NOT_INITIALIZED 0x00010001
 /*! @brief No context is current for this thread.
  *
  *  This occurs if a GLFW function was called that needs and operates on the
@@ -684,7 +682,7 @@ extern "C" {
  *  @analysis Application programmer error.  Ensure a context is current before
  *  calling functions that require a current context.
  */
-#define GLFW_NO_CURRENT_CONTEXT     0x00010002
+#define GLFW_NO_CURRENT_CONTEXT 0x00010002
 /*! @brief One of the arguments to the function was an invalid enum value.
  *
  *  One of the arguments to the function was an invalid enum value, for example
@@ -692,7 +690,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_INVALID_ENUM           0x00010003
+#define GLFW_INVALID_ENUM 0x00010003
 /*! @brief One of the arguments to the function was an invalid value.
  *
  *  One of the arguments to the function was an invalid value, for example
@@ -703,7 +701,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_INVALID_VALUE          0x00010004
+#define GLFW_INVALID_VALUE 0x00010004
 /*! @brief A memory allocation failed.
  *
  *  A memory allocation failed.
@@ -711,7 +709,7 @@ extern "C" {
  *  @analysis A bug in GLFW or the underlying operating system.  Report the bug
  *  to our [issue tracker](https://github.com/glfw/glfw/issues).
  */
-#define GLFW_OUT_OF_MEMORY          0x00010005
+#define GLFW_OUT_OF_MEMORY 0x00010005
 /*! @brief GLFW could not find support for the requested API on the system.
  *
  *  GLFW could not find support for the requested API on the system.
@@ -727,7 +725,7 @@ extern "C" {
  *  EGL, OpenGL and OpenGL ES libraries do not interface with the Nvidia binary
  *  driver.  Older graphics drivers do not support Vulkan.
  */
-#define GLFW_API_UNAVAILABLE        0x00010006
+#define GLFW_API_UNAVAILABLE 0x00010006
 /*! @brief The requested OpenGL or OpenGL ES version is not available.
  *
  *  The requested OpenGL or OpenGL ES version (including any requested context
@@ -744,7 +742,7 @@ extern "C" {
  *  not @ref GLFW_INVALID_VALUE, because GLFW cannot know what future versions
  *  will exist.
  */
-#define GLFW_VERSION_UNAVAILABLE    0x00010007
+#define GLFW_VERSION_UNAVAILABLE 0x00010007
 /*! @brief A platform-specific error occurred that does not match any of the
  *  more specific categories.
  *
@@ -755,7 +753,7 @@ extern "C" {
  *  system or its drivers, or a lack of required resources.  Report the issue to
  *  our [issue tracker](https://github.com/glfw/glfw/issues).
  */
-#define GLFW_PLATFORM_ERROR         0x00010008
+#define GLFW_PLATFORM_ERROR 0x00010008
 /*! @brief The requested format is not supported or available.
  *
  *  If emitted during window creation, the requested pixel format is not
@@ -774,7 +772,7 @@ extern "C" {
  *  If emitted when querying the clipboard, ignore the error or report it to
  *  the user, as appropriate.
  */
-#define GLFW_FORMAT_UNAVAILABLE     0x00010009
+#define GLFW_FORMAT_UNAVAILABLE 0x00010009
 /*! @brief The specified window does not have an OpenGL or OpenGL ES context.
  *
  *  A window that does not have an OpenGL or OpenGL ES context was passed to
@@ -782,7 +780,7 @@ extern "C" {
  *
  *  @analysis Application programmer error.  Fix the offending call.
  */
-#define GLFW_NO_WINDOW_CONTEXT      0x0001000A
+#define GLFW_NO_WINDOW_CONTEXT 0x0001000A
 /*! @brief The specified cursor shape is not available.
  *
  *  The specified standard cursor shape is not available, either because the
@@ -793,7 +791,7 @@ extern "C" {
  *  [standard cursor shape](@ref shapes) or create a
  *  [custom cursor](@ref cursor_custom).
  */
-#define GLFW_CURSOR_UNAVAILABLE     0x0001000B
+#define GLFW_CURSOR_UNAVAILABLE 0x0001000B
 /*! @brief The requested feature is not provided by the platform.
  *
  *  The requested feature is not provided by the platform, so GLFW is unable to
@@ -807,7 +805,7 @@ extern "C" {
  *  A function call that emits this error has no effect other than the error and
  *  updating any existing out parameters.
  */
-#define GLFW_FEATURE_UNAVAILABLE    0x0001000C
+#define GLFW_FEATURE_UNAVAILABLE 0x0001000C
 /*! @brief The requested feature is not implemented for the platform.
  *
  *  The requested feature has not yet been implemented in GLFW for this platform.
@@ -820,7 +818,7 @@ extern "C" {
  *  A function call that emits this error has no effect other than the error and
  *  updating any existing out parameters.
  */
-#define GLFW_FEATURE_UNIMPLEMENTED  0x0001000D
+#define GLFW_FEATURE_UNIMPLEMENTED 0x0001000D
 /*! @} */
 
 /*! @addtogroup window
@@ -830,59 +828,59 @@ extern "C" {
  *  Input focus [window hint](@ref GLFW_FOCUSED_hint) or
  *  [window attribute](@ref GLFW_FOCUSED_attrib).
  */
-#define GLFW_FOCUSED                0x00020001
+#define GLFW_FOCUSED 0x00020001
 /*! @brief Window iconification window attribute
  *
  *  Window iconification [window attribute](@ref GLFW_ICONIFIED_attrib).
  */
-#define GLFW_ICONIFIED              0x00020002
+#define GLFW_ICONIFIED 0x00020002
 /*! @brief Window resize-ability window hint and attribute
  *
  *  Window resize-ability [window hint](@ref GLFW_RESIZABLE_hint) and
  *  [window attribute](@ref GLFW_RESIZABLE_attrib).
  */
-#define GLFW_RESIZABLE              0x00020003
+#define GLFW_RESIZABLE 0x00020003
 /*! @brief Window visibility window hint and attribute
  *
  *  Window visibility [window hint](@ref GLFW_VISIBLE_hint) and
  *  [window attribute](@ref GLFW_VISIBLE_attrib).
  */
-#define GLFW_VISIBLE                0x00020004
+#define GLFW_VISIBLE 0x00020004
 /*! @brief Window decoration window hint and attribute
  *
  *  Window decoration [window hint](@ref GLFW_DECORATED_hint) and
  *  [window attribute](@ref GLFW_DECORATED_attrib).
  */
-#define GLFW_DECORATED              0x00020005
+#define GLFW_DECORATED 0x00020005
 /*! @brief Window auto-iconification window hint and attribute
  *
  *  Window auto-iconification [window hint](@ref GLFW_AUTO_ICONIFY_hint) and
  *  [window attribute](@ref GLFW_AUTO_ICONIFY_attrib).
  */
-#define GLFW_AUTO_ICONIFY           0x00020006
+#define GLFW_AUTO_ICONIFY 0x00020006
 /*! @brief Window decoration window hint and attribute
  *
  *  Window decoration [window hint](@ref GLFW_FLOATING_hint) and
  *  [window attribute](@ref GLFW_FLOATING_attrib).
  */
-#define GLFW_FLOATING               0x00020007
+#define GLFW_FLOATING 0x00020007
 /*! @brief Window maximization window hint and attribute
  *
  *  Window maximization [window hint](@ref GLFW_MAXIMIZED_hint) and
  *  [window attribute](@ref GLFW_MAXIMIZED_attrib).
  */
-#define GLFW_MAXIMIZED              0x00020008
+#define GLFW_MAXIMIZED 0x00020008
 /*! @brief Cursor centering window hint
  *
  *  Cursor centering [window hint](@ref GLFW_CENTER_CURSOR_hint).
  */
-#define GLFW_CENTER_CURSOR          0x00020009
+#define GLFW_CENTER_CURSOR 0x00020009
 
 /*! @brief Parent native window pointer hint
  *
  *  Parent window for embedding [window hint](@ref GLFW_NATIVE_PARENT_hint).
  */
-#define GLFW_NATIVE_PARENT_HANDLE   0x0002000A
+#define GLFW_NATIVE_PARENT_HANDLE 0x0002000A
 /*! @brief Window framebuffer transparency hint and attribute
  *
  *  Window framebuffer transparency
@@ -894,156 +892,181 @@ extern "C" {
  *
  *  Mouse cursor hover [window attribute](@ref GLFW_HOVERED_attrib).
  */
-#define GLFW_HOVERED                0x0002000B
+#define GLFW_HOVERED 0x0002000B
 /*! @brief Input focus on calling show window hint and attribute
  *
  *  Input focus [window hint](@ref GLFW_FOCUS_ON_SHOW_hint) or
  *  [window attribute](@ref GLFW_FOCUS_ON_SHOW_attrib).
  */
-#define GLFW_FOCUS_ON_SHOW          0x0002000C
+#define GLFW_FOCUS_ON_SHOW 0x0002000C
 
 /*! @brief Mouse input transparency window hint and attribute
  *
  *  Mouse input transparency [window hint](@ref GLFW_MOUSE_PASSTHROUGH_hint) or
  *  [window attribute](@ref GLFW_MOUSE_PASSTHROUGH_attrib).
  */
-#define GLFW_MOUSE_PASSTHROUGH      0x0002000D
+#define GLFW_MOUSE_PASSTHROUGH 0x0002000D
+
+/*! @brief Is _NET_WM_WINDOW_TYPE_DESKTOP hint
+ *
+ */
+#define GLFW_NET_WM_WINDOW_TYPE_DESKTOP 0x0002000E
+
+/*! @brief Is sticky window hint
+ *
+ */
+#define GLFW_STICKY_WINDOW 0x0002000F
+
+/*! @brief Is below window hint
+ *
+ */
+#define GLFW_BELOW 0x00020010
+
+/*! @brief Is skip taskbar window hint
+ *
+ */
+#define GLFW_SKIP_TASKBAR 0x00020011
+
+/*! @brief Is skip pager window hint
+ *
+ */
+#define GLFW_SKIP_PAGER 0x00020012
 
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_RED_BITS).
  */
-#define GLFW_RED_BITS               0x00021001
+#define GLFW_RED_BITS 0x00021001
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_GREEN_BITS).
  */
-#define GLFW_GREEN_BITS             0x00021002
+#define GLFW_GREEN_BITS 0x00021002
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_BLUE_BITS).
  */
-#define GLFW_BLUE_BITS              0x00021003
+#define GLFW_BLUE_BITS 0x00021003
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ALPHA_BITS).
  */
-#define GLFW_ALPHA_BITS             0x00021004
+#define GLFW_ALPHA_BITS 0x00021004
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_DEPTH_BITS).
  */
-#define GLFW_DEPTH_BITS             0x00021005
+#define GLFW_DEPTH_BITS 0x00021005
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_STENCIL_BITS).
  */
-#define GLFW_STENCIL_BITS           0x00021006
+#define GLFW_STENCIL_BITS 0x00021006
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_RED_BITS).
  */
-#define GLFW_ACCUM_RED_BITS         0x00021007
+#define GLFW_ACCUM_RED_BITS 0x00021007
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_GREEN_BITS).
  */
-#define GLFW_ACCUM_GREEN_BITS       0x00021008
+#define GLFW_ACCUM_GREEN_BITS 0x00021008
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_BLUE_BITS).
  */
-#define GLFW_ACCUM_BLUE_BITS        0x00021009
+#define GLFW_ACCUM_BLUE_BITS 0x00021009
 /*! @brief Framebuffer bit depth hint.
  *
  *  Framebuffer bit depth [hint](@ref GLFW_ACCUM_ALPHA_BITS).
  */
-#define GLFW_ACCUM_ALPHA_BITS       0x0002100A
+#define GLFW_ACCUM_ALPHA_BITS 0x0002100A
 /*! @brief Framebuffer auxiliary buffer hint.
  *
  *  Framebuffer auxiliary buffer [hint](@ref GLFW_AUX_BUFFERS).
  */
-#define GLFW_AUX_BUFFERS            0x0002100B
+#define GLFW_AUX_BUFFERS 0x0002100B
 /*! @brief OpenGL stereoscopic rendering hint.
  *
  *  OpenGL stereoscopic rendering [hint](@ref GLFW_STEREO).
  */
-#define GLFW_STEREO                 0x0002100C
+#define GLFW_STEREO 0x0002100C
 /*! @brief Framebuffer MSAA samples hint.
  *
  *  Framebuffer MSAA samples [hint](@ref GLFW_SAMPLES).
  */
-#define GLFW_SAMPLES                0x0002100D
+#define GLFW_SAMPLES 0x0002100D
 /*! @brief Framebuffer sRGB hint.
  *
  *  Framebuffer sRGB [hint](@ref GLFW_SRGB_CAPABLE).
  */
-#define GLFW_SRGB_CAPABLE           0x0002100E
+#define GLFW_SRGB_CAPABLE 0x0002100E
 /*! @brief Monitor refresh rate hint.
  *
  *  Monitor refresh rate [hint](@ref GLFW_REFRESH_RATE).
  */
-#define GLFW_REFRESH_RATE           0x0002100F
+#define GLFW_REFRESH_RATE 0x0002100F
 /*! @brief Framebuffer double buffering hint and attribute.
  *
  *  Framebuffer double buffering [hint](@ref GLFW_DOUBLEBUFFER_hint) and
  *  [attribute](@ref GLFW_DOUBLEBUFFER_attrib).
  */
-#define GLFW_DOUBLEBUFFER           0x00021010
+#define GLFW_DOUBLEBUFFER 0x00021010
 
 /*! @brief Context client API hint and attribute.
  *
  *  Context client API [hint](@ref GLFW_CLIENT_API_hint) and
  *  [attribute](@ref GLFW_CLIENT_API_attrib).
  */
-#define GLFW_CLIENT_API             0x00022001
+#define GLFW_CLIENT_API 0x00022001
 /*! @brief Context client API major version hint and attribute.
  *
  *  Context client API major version [hint](@ref GLFW_CONTEXT_VERSION_MAJOR_hint)
  *  and [attribute](@ref GLFW_CONTEXT_VERSION_MAJOR_attrib).
  */
-#define GLFW_CONTEXT_VERSION_MAJOR  0x00022002
+#define GLFW_CONTEXT_VERSION_MAJOR 0x00022002
 /*! @brief Context client API minor version hint and attribute.
  *
  *  Context client API minor version [hint](@ref GLFW_CONTEXT_VERSION_MINOR_hint)
  *  and [attribute](@ref GLFW_CONTEXT_VERSION_MINOR_attrib).
  */
-#define GLFW_CONTEXT_VERSION_MINOR  0x00022003
+#define GLFW_CONTEXT_VERSION_MINOR 0x00022003
 /*! @brief Context client API revision number hint and attribute.
  *
  *  Context client API revision number
  *  [attribute](@ref GLFW_CONTEXT_REVISION_attrib).
  */
-#define GLFW_CONTEXT_REVISION       0x00022004
+#define GLFW_CONTEXT_REVISION 0x00022004
 /*! @brief Context robustness hint and attribute.
  *
  *  Context client API revision number [hint](@ref GLFW_CONTEXT_ROBUSTNESS_hint)
  *  and [attribute](@ref GLFW_CONTEXT_ROBUSTNESS_attrib).
  */
-#define GLFW_CONTEXT_ROBUSTNESS     0x00022005
+#define GLFW_CONTEXT_ROBUSTNESS 0x00022005
 /*! @brief OpenGL forward-compatibility hint and attribute.
  *
  *  OpenGL forward-compatibility [hint](@ref GLFW_OPENGL_FORWARD_COMPAT_hint)
  *  and [attribute](@ref GLFW_OPENGL_FORWARD_COMPAT_attrib).
  */
-#define GLFW_OPENGL_FORWARD_COMPAT  0x00022006
+#define GLFW_OPENGL_FORWARD_COMPAT 0x00022006
 /*! @brief Debug mode context hint and attribute.
  *
  *  Debug mode context [hint](@ref GLFW_CONTEXT_DEBUG_hint) and
  *  [attribute](@ref GLFW_CONTEXT_DEBUG_attrib).
  */
-#define GLFW_CONTEXT_DEBUG          0x00022007
+#define GLFW_CONTEXT_DEBUG 0x00022007
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_OPENGL_DEBUG_CONTEXT   GLFW_CONTEXT_DEBUG
+#define GLFW_OPENGL_DEBUG_CONTEXT GLFW_CONTEXT_DEBUG
 /*! @brief OpenGL profile hint and attribute.
  *
  *  OpenGL profile [hint](@ref GLFW_OPENGL_PROFILE_hint) and
  *  [attribute](@ref GLFW_OPENGL_PROFILE_attrib).
  */
-#define GLFW_OPENGL_PROFILE         0x00022008
+#define GLFW_OPENGL_PROFILE 0x00022008
 /*! @brief Context flush-on-release hint and attribute.
  *
  *  Context flush-on-release [hint](@ref GLFW_CONTEXT_RELEASE_BEHAVIOR_hint) and
@@ -1055,17 +1078,17 @@ extern "C" {
  *  Context error suppression [hint](@ref GLFW_CONTEXT_NO_ERROR_hint) and
  *  [attribute](@ref GLFW_CONTEXT_NO_ERROR_attrib).
  */
-#define GLFW_CONTEXT_NO_ERROR       0x0002200A
+#define GLFW_CONTEXT_NO_ERROR 0x0002200A
 /*! @brief Context creation API hint and attribute.
  *
  *  Context creation API [hint](@ref GLFW_CONTEXT_CREATION_API_hint) and
  *  [attribute](@ref GLFW_CONTEXT_CREATION_API_attrib).
  */
-#define GLFW_CONTEXT_CREATION_API   0x0002200B
+#define GLFW_CONTEXT_CREATION_API 0x0002200B
 /*! @brief Window content area scaling window
  *  [window hint](@ref GLFW_SCALE_TO_MONITOR).
  */
-#define GLFW_SCALE_TO_MONITOR       0x0002200C
+#define GLFW_SCALE_TO_MONITOR 0x0002200C
 /*! @brief macOS specific
  *  [window hint](@ref GLFW_COCOA_RETINA_FRAMEBUFFER_hint).
  */
@@ -1073,7 +1096,7 @@ extern "C" {
 /*! @brief macOS specific
  *  [window hint](@ref GLFW_COCOA_FRAME_NAME_hint).
  */
-#define GLFW_COCOA_FRAME_NAME         0x00023002
+#define GLFW_COCOA_FRAME_NAME 0x00023002
 /*! @brief macOS specific
  *  [window hint](@ref GLFW_COCOA_GRAPHICS_SWITCHING_hint).
  */
@@ -1081,51 +1104,51 @@ extern "C" {
 /*! @brief X11 specific
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
-#define GLFW_X11_CLASS_NAME         0x00024001
+#define GLFW_X11_CLASS_NAME 0x00024001
 /*! @brief X11 specific
  *  [window hint](@ref GLFW_X11_CLASS_NAME_hint).
  */
-#define GLFW_X11_INSTANCE_NAME      0x00024002
-#define GLFW_WIN32_KEYBOARD_MENU    0x00025001
-/*! @} */
+#define GLFW_X11_INSTANCE_NAME 0x00024002
+#define GLFW_WIN32_KEYBOARD_MENU 0x00025001
+    /*! @} */
 
-#define GLFW_NO_API                          0
-#define GLFW_OPENGL_API             0x00030001
-#define GLFW_OPENGL_ES_API          0x00030002
+#define GLFW_NO_API 0
+#define GLFW_OPENGL_API 0x00030001
+#define GLFW_OPENGL_ES_API 0x00030002
 
-#define GLFW_NO_ROBUSTNESS                   0
-#define GLFW_NO_RESET_NOTIFICATION  0x00031001
-#define GLFW_LOSE_CONTEXT_ON_RESET  0x00031002
+#define GLFW_NO_ROBUSTNESS 0
+#define GLFW_NO_RESET_NOTIFICATION 0x00031001
+#define GLFW_LOSE_CONTEXT_ON_RESET 0x00031002
 
-#define GLFW_OPENGL_ANY_PROFILE              0
-#define GLFW_OPENGL_CORE_PROFILE    0x00032001
-#define GLFW_OPENGL_COMPAT_PROFILE  0x00032002
+#define GLFW_OPENGL_ANY_PROFILE 0
+#define GLFW_OPENGL_CORE_PROFILE 0x00032001
+#define GLFW_OPENGL_COMPAT_PROFILE 0x00032002
 
-#define GLFW_CURSOR                 0x00033001
-#define GLFW_STICKY_KEYS            0x00033002
-#define GLFW_STICKY_MOUSE_BUTTONS   0x00033003
-#define GLFW_LOCK_KEY_MODS          0x00033004
-#define GLFW_RAW_MOUSE_MOTION       0x00033005
+#define GLFW_CURSOR 0x00033001
+#define GLFW_STICKY_KEYS 0x00033002
+#define GLFW_STICKY_MOUSE_BUTTONS 0x00033003
+#define GLFW_LOCK_KEY_MODS 0x00033004
+#define GLFW_RAW_MOUSE_MOTION 0x00033005
 
-#define GLFW_CURSOR_NORMAL          0x00034001
-#define GLFW_CURSOR_HIDDEN          0x00034002
-#define GLFW_CURSOR_DISABLED        0x00034003
+#define GLFW_CURSOR_NORMAL 0x00034001
+#define GLFW_CURSOR_HIDDEN 0x00034002
+#define GLFW_CURSOR_DISABLED 0x00034003
 
-#define GLFW_ANY_RELEASE_BEHAVIOR            0
+#define GLFW_ANY_RELEASE_BEHAVIOR 0
 #define GLFW_RELEASE_BEHAVIOR_FLUSH 0x00035001
-#define GLFW_RELEASE_BEHAVIOR_NONE  0x00035002
+#define GLFW_RELEASE_BEHAVIOR_NONE 0x00035002
 
-#define GLFW_NATIVE_CONTEXT_API     0x00036001
-#define GLFW_EGL_CONTEXT_API        0x00036002
-#define GLFW_OSMESA_CONTEXT_API     0x00036003
+#define GLFW_NATIVE_CONTEXT_API 0x00036001
+#define GLFW_EGL_CONTEXT_API 0x00036002
+#define GLFW_OSMESA_CONTEXT_API 0x00036003
 
-#define GLFW_ANGLE_PLATFORM_TYPE_NONE    0x00037001
-#define GLFW_ANGLE_PLATFORM_TYPE_OPENGL  0x00037002
+#define GLFW_ANGLE_PLATFORM_TYPE_NONE 0x00037001
+#define GLFW_ANGLE_PLATFORM_TYPE_OPENGL 0x00037002
 #define GLFW_ANGLE_PLATFORM_TYPE_OPENGLES 0x00037003
-#define GLFW_ANGLE_PLATFORM_TYPE_D3D9    0x00037004
-#define GLFW_ANGLE_PLATFORM_TYPE_D3D11   0x00037005
-#define GLFW_ANGLE_PLATFORM_TYPE_VULKAN  0x00037007
-#define GLFW_ANGLE_PLATFORM_TYPE_METAL   0x00037008
+#define GLFW_ANGLE_PLATFORM_TYPE_D3D9 0x00037004
+#define GLFW_ANGLE_PLATFORM_TYPE_D3D11 0x00037005
+#define GLFW_ANGLE_PLATFORM_TYPE_VULKAN 0x00037007
+#define GLFW_ANGLE_PLATFORM_TYPE_METAL 0x00037008
 
 /*! @defgroup shapes Standard cursor shapes
  *  @brief Standard system cursor shapes.
@@ -1140,34 +1163,34 @@ extern "C" {
  *
  *  The regular arrow cursor shape.
  */
-#define GLFW_ARROW_CURSOR           0x00036001
+#define GLFW_ARROW_CURSOR 0x00036001
 /*! @brief The text input I-beam cursor shape.
  *
  *  The text input I-beam cursor shape.
  */
-#define GLFW_IBEAM_CURSOR           0x00036002
+#define GLFW_IBEAM_CURSOR 0x00036002
 /*! @brief The crosshair cursor shape.
  *
  *  The crosshair cursor shape.
  */
-#define GLFW_CROSSHAIR_CURSOR       0x00036003
+#define GLFW_CROSSHAIR_CURSOR 0x00036003
 /*! @brief The pointing hand cursor shape.
  *
  *  The pointing hand cursor shape.
  */
-#define GLFW_POINTING_HAND_CURSOR   0x00036004
+#define GLFW_POINTING_HAND_CURSOR 0x00036004
 /*! @brief The horizontal resize/move arrow shape.
  *
  *  The horizontal resize/move arrow shape.  This is usually a horizontal
  *  double-headed arrow.
  */
-#define GLFW_RESIZE_EW_CURSOR       0x00036005
+#define GLFW_RESIZE_EW_CURSOR 0x00036005
 /*! @brief The vertical resize/move arrow shape.
  *
  *  The vertical resize/move shape.  This is usually a vertical double-headed
  *  arrow.
  */
-#define GLFW_RESIZE_NS_CURSOR       0x00036006
+#define GLFW_RESIZE_NS_CURSOR 0x00036006
 /*! @brief The top-left to bottom-right diagonal resize/move arrow shape.
  *
  *  The top-left to bottom-right diagonal resize/move shape.  This is usually
@@ -1182,7 +1205,7 @@ extern "C" {
  *  @note @wayland This shape is provided by a newer standard not supported by
  *  all cursor themes.
  */
-#define GLFW_RESIZE_NWSE_CURSOR     0x00036007
+#define GLFW_RESIZE_NWSE_CURSOR 0x00036007
 /*! @brief The top-right to bottom-left diagonal resize/move arrow shape.
  *
  *  The top-right to bottom-left diagonal resize/move shape.  This is usually
@@ -1197,13 +1220,13 @@ extern "C" {
  *  @note @wayland This shape is provided by a newer standard not supported by
  *  all cursor themes.
  */
-#define GLFW_RESIZE_NESW_CURSOR     0x00036008
+#define GLFW_RESIZE_NESW_CURSOR 0x00036008
 /*! @brief The omni-directional resize/move cursor shape.
  *
  *  The omni-directional resize cursor/move shape.  This is usually either
  *  a combined horizontal and vertical double-headed arrow or a grabbing hand.
  */
-#define GLFW_RESIZE_ALL_CURSOR      0x00036009
+#define GLFW_RESIZE_ALL_CURSOR 0x00036009
 /*! @brief The operation-not-allowed shape.
  *
  *  The operation-not-allowed shape.  This is usually a circle with a diagonal
@@ -1215,26 +1238,26 @@ extern "C" {
  *  @note @wayland This shape is provided by a newer standard not supported by
  *  all cursor themes.
  */
-#define GLFW_NOT_ALLOWED_CURSOR     0x0003600A
+#define GLFW_NOT_ALLOWED_CURSOR 0x0003600A
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_HRESIZE_CURSOR         GLFW_RESIZE_EW_CURSOR
+#define GLFW_HRESIZE_CURSOR GLFW_RESIZE_EW_CURSOR
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_VRESIZE_CURSOR         GLFW_RESIZE_NS_CURSOR
+#define GLFW_VRESIZE_CURSOR GLFW_RESIZE_NS_CURSOR
 /*! @brief Legacy name for compatibility.
  *
  *  This is an alias for compatibility with earlier versions.
  */
-#define GLFW_HAND_CURSOR            GLFW_POINTING_HAND_CURSOR
-/*! @} */
+#define GLFW_HAND_CURSOR GLFW_POINTING_HAND_CURSOR
+    /*! @} */
 
-#define GLFW_CONNECTED              0x00040001
-#define GLFW_DISCONNECTED           0x00040002
+#define GLFW_CONNECTED 0x00040001
+#define GLFW_DISCONNECTED 0x00040002
 
 /*! @addtogroup init
  *  @{ */
@@ -1242,5193 +1265,5187 @@ extern "C" {
  *
  *  Joystick hat buttons [init hint](@ref GLFW_JOYSTICK_HAT_BUTTONS).
  */
-#define GLFW_JOYSTICK_HAT_BUTTONS   0x00050001
+#define GLFW_JOYSTICK_HAT_BUTTONS 0x00050001
 /*! @brief ANGLE rendering backend init hint.
  *
  *  ANGLE rendering backend [init hint](@ref GLFW_ANGLE_PLATFORM_TYPE_hint).
  */
-#define GLFW_ANGLE_PLATFORM_TYPE    0x00050002
+#define GLFW_ANGLE_PLATFORM_TYPE 0x00050002
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_CHDIR_RESOURCES_hint).
  */
-#define GLFW_COCOA_CHDIR_RESOURCES  0x00051001
+#define GLFW_COCOA_CHDIR_RESOURCES 0x00051001
 /*! @brief macOS specific init hint.
  *
  *  macOS specific [init hint](@ref GLFW_COCOA_MENUBAR_hint).
  */
-#define GLFW_COCOA_MENUBAR          0x00051002
+#define GLFW_COCOA_MENUBAR 0x00051002
 /*! @brief X11 specific init hint.
  *
  *  X11 specific [init hint](@ref GLFW_X11_XCB_VULKAN_SURFACE_hint).
  */
 #define GLFW_X11_XCB_VULKAN_SURFACE 0x00052001
-/*! @} */
+    /*! @} */
 
-#define GLFW_DONT_CARE              -1
+#define GLFW_DONT_CARE -1
 
+    /*************************************************************************
+     * GLFW API types
+     *************************************************************************/
 
-/*************************************************************************
- * GLFW API types
- *************************************************************************/
-
-/*! @brief Client API function pointer type.
- *
- *  Generic function pointer used for returning client API function pointers
- *  without forcing a cast from a regular pointer.
- *
- *  @sa @ref context_glext
- *  @sa @ref glfwGetProcAddress
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup context
- */
-typedef void (*GLFWglproc)(void);
-
-/*! @brief Vulkan API function pointer type.
- *
- *  Generic function pointer used for returning Vulkan API function pointers
- *  without forcing a cast from a regular pointer.
- *
- *  @sa @ref vulkan_proc
- *  @sa @ref glfwGetInstanceProcAddress
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup vulkan
- */
-typedef void (*GLFWvkproc)(void);
-
-/*! @brief Opaque monitor object.
- *
- *  Opaque monitor object.
- *
- *  @see @ref monitor_object
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-typedef struct GLFWmonitor GLFWmonitor;
-
-/*! @brief Opaque window object.
- *
- *  Opaque window object.
- *
- *  @see @ref window_object
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-typedef struct GLFWwindow GLFWwindow;
-
-/*! @brief Opaque user OpenGL & OpenGL ES context object.
- *
- *  Opaque user OpenGL OpenGL ES context object.
- *
- *  @see @ref context_user
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup window
- */
-typedef struct GLFWusercontext GLFWusercontext;
-
-/*! @brief Opaque cursor object.
- *
- *  Opaque cursor object.
- *
- *  @see @ref cursor_object
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-typedef struct GLFWcursor GLFWcursor;
-
-/*! @brief The function pointer type for memory allocation callbacks.
- *
- *  This is the function pointer type for memory allocation callbacks.  A memory
- *  allocation callback function has the following signature:
- *  @code
- *  void* function_name(size_t size, void* user)
- *  @endcode
- *
- *  This function must return either a memory block at least `size` bytes long,
- *  or `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
- *  failures gracefully yet.
- *
- *  This function may be called during @ref glfwInit but before the library is
- *  flagged as initialized, as well as during @ref glfwTerminate after the
- *  library is no longer flagged as initialized.
- *
- *  Any memory allocated by this function will be deallocated during library
- *  termination or earlier.
- *
- *  The size will always be greater than zero.  Allocations of size zero are filtered out
- *  before reaching the custom allocator.
- *
- *  @param[in] size The minimum size, in bytes, of the memory block.
- *  @param[in] user The user-defined pointer from the allocator.
- *  @return The address of the newly allocated memory block, or `NULL` if an
- *  error occurred.
- *
- *  @pointer_lifetime The returned memory block must be valid at least until it
- *  is deallocated.
- *
- *  @reentrancy This function should not call any GLFW function.
- *
- *  @thread_safety This function may be called from any thread that calls GLFW functions.
- *
- *  @sa @ref init_allocator
- *  @sa @ref GLFWallocator
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup init
- */
-typedef void* (* GLFWallocatefun)(size_t size, void* user);
-
-/*! @brief The function pointer type for memory reallocation callbacks.
- *
- *  This is the function pointer type for memory reallocation callbacks.
- *  A memory reallocation callback function has the following signature:
- *  @code
- *  void* function_name(void* block, size_t size, void* user)
- *  @endcode
- *
- *  This function must return a memory block at least `size` bytes long, or
- *  `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
- *  failures gracefully yet.
- *
- *  This function may be called during @ref glfwInit but before the library is
- *  flagged as initialized, as well as during @ref glfwTerminate after the
- *  library is no longer flagged as initialized.
- *
- *  Any memory allocated by this function will be deallocated during library
- *  termination or earlier.
- *
- *  The block address will never be `NULL` and the size will always be greater than zero.
- *  Reallocations of a block to size zero are converted into deallocations.  Reallocations
- *  of `NULL` to a non-zero size are converted into regular allocations.
- *
- *  @param[in] block The address of the memory block to reallocate.
- *  @param[in] size The new minimum size, in bytes, of the memory block.
- *  @param[in] user The user-defined pointer from the allocator.
- *  @return The address of the newly allocated or resized memory block, or
- *  `NULL` if an error occurred.
- *
- *  @pointer_lifetime The returned memory block must be valid at least until it
- *  is deallocated.
- *
- *  @reentrancy This function should not call any GLFW function.
- *
- *  @thread_safety This function may be called from any thread that calls GLFW functions.
- *
- *  @sa @ref init_allocator
- *  @sa @ref GLFWallocator
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup init
- */
-typedef void* (* GLFWreallocatefun)(void* block, size_t size, void* user);
-
-/*! @brief The function pointer type for memory deallocation callbacks.
- *
- *  This is the function pointer type for memory deallocation callbacks.
- *  A memory deallocation callback function has the following signature:
- *  @code
- *  void function_name(void* block, void* user)
- *  @endcode
- *
- *  This function may deallocate the specified memory block.  This memory block
- *  will have been allocated with the same allocator.
- *
- *  This function may be called during @ref glfwInit but before the library is
- *  flagged as initialized, as well as during @ref glfwTerminate after the
- *  library is no longer flagged as initialized.
- *
- *  The block address will never be `NULL`.  Deallocations of `NULL` are filtered out
- *  before reaching the custom allocator.
- *
- *  @param[in] block The address of the memory block to deallocate.
- *  @param[in] user The user-defined pointer from the allocator.
- *
- *  @pointer_lifetime The specified memory block will not be accessed by GLFW
- *  after this function is called.
- *
- *  @reentrancy This function should not call any GLFW function.
- *
- *  @thread_safety This function may be called from any thread that calls GLFW functions.
- *
- *  @sa @ref init_allocator
- *  @sa @ref GLFWallocator
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup init
- */
-typedef void (* GLFWdeallocatefun)(void* block, void* user);
-
-/*! @brief The function pointer type for error callbacks.
- *
- *  This is the function pointer type for error callbacks.  An error callback
- *  function has the following signature:
- *  @code
- *  void callback_name(int error_code, const char* description)
- *  @endcode
- *
- *  @param[in] error_code An [error code](@ref errors).  Future releases may add
- *  more error codes.
- *  @param[in] description A UTF-8 encoded string describing the error.
- *
- *  @pointer_lifetime The error description string is valid until the callback
- *  function returns.
- *
- *  @sa @ref error_handling
- *  @sa @ref glfwSetErrorCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup init
- */
-typedef void (* GLFWerrorfun)(int error_code, const char* description);
-
-/*! @brief The function pointer type for window position callbacks.
- *
- *  This is the function pointer type for window position callbacks.  A window
- *  position callback function has the following signature:
- *  @code
- *  void callback_name(GLFWwindow* window, int xpos, int ypos)
- *  @endcode
- *
- *  @param[in] window The window that was moved.
- *  @param[in] xpos The new x-coordinate, in screen coordinates, of the
- *  upper-left corner of the content area of the window.
- *  @param[in] ypos The new y-coordinate, in screen coordinates, of the
- *  upper-left corner of the content area of the window.
- *
- *  @sa @ref window_pos
- *  @sa @ref glfwSetWindowPosCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowposfun)(GLFWwindow* window, int xpos, int ypos);
-
-/*! @brief The function pointer type for window size callbacks.
- *
- *  This is the function pointer type for window size callbacks.  A window size
- *  callback function has the following signature:
- *  @code
- *  void callback_name(GLFWwindow* window, int width, int height)
- *  @endcode
- *
- *  @param[in] window The window that was resized.
- *  @param[in] width The new width, in screen coordinates, of the window.
- *  @param[in] height The new height, in screen coordinates, of the window.
- *
- *  @sa @ref window_size
- *  @sa @ref glfwSetWindowSizeCallback
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowsizefun)(GLFWwindow* window, int width, int height);
-
-/*! @brief The function pointer type for window close callbacks.
- *
- *  This is the function pointer type for window close callbacks.  A window
- *  close callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window)
- *  @endcode
- *
- *  @param[in] window The window that the user attempted to close.
- *
- *  @sa @ref window_close
- *  @sa @ref glfwSetWindowCloseCallback
- *
- *  @since Added in version 2.5.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowclosefun)(GLFWwindow* window);
-
-/*! @brief The function pointer type for window content refresh callbacks.
- *
- *  This is the function pointer type for window content refresh callbacks.
- *  A window content refresh callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window);
- *  @endcode
- *
- *  @param[in] window The window whose content needs to be refreshed.
- *
- *  @sa @ref window_refresh
- *  @sa @ref glfwSetWindowRefreshCallback
- *
- *  @since Added in version 2.5.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowrefreshfun)(GLFWwindow* window);
-
-/*! @brief The function pointer type for window focus callbacks.
- *
- *  This is the function pointer type for window focus callbacks.  A window
- *  focus callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int focused)
- *  @endcode
- *
- *  @param[in] window The window that gained or lost input focus.
- *  @param[in] focused `GLFW_TRUE` if the window was given input focus, or
- *  `GLFW_FALSE` if it lost it.
- *
- *  @sa @ref window_focus
- *  @sa @ref glfwSetWindowFocusCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowfocusfun)(GLFWwindow* window, int focused);
-
-/*! @brief The function pointer type for window iconify callbacks.
- *
- *  This is the function pointer type for window iconify callbacks.  A window
- *  iconify callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int iconified)
- *  @endcode
- *
- *  @param[in] window The window that was iconified or restored.
- *  @param[in] iconified `GLFW_TRUE` if the window was iconified, or
- *  `GLFW_FALSE` if it was restored.
- *
- *  @sa @ref window_iconify
- *  @sa @ref glfwSetWindowIconifyCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowiconifyfun)(GLFWwindow* window, int iconified);
-
-/*! @brief The function pointer type for window maximize callbacks.
- *
- *  This is the function pointer type for window maximize callbacks.  A window
- *  maximize callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int maximized)
- *  @endcode
- *
- *  @param[in] window The window that was maximized or restored.
- *  @param[in] maximized `GLFW_TRUE` if the window was maximized, or
- *  `GLFW_FALSE` if it was restored.
- *
- *  @sa @ref window_maximize
- *  @sa glfwSetWindowMaximizeCallback
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowmaximizefun)(GLFWwindow* window, int maximized);
-
-/*! @brief The function pointer type for framebuffer size callbacks.
- *
- *  This is the function pointer type for framebuffer size callbacks.
- *  A framebuffer size callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int width, int height)
- *  @endcode
- *
- *  @param[in] window The window whose framebuffer was resized.
- *  @param[in] width The new width, in pixels, of the framebuffer.
- *  @param[in] height The new height, in pixels, of the framebuffer.
- *
- *  @sa @ref window_fbsize
- *  @sa @ref glfwSetFramebufferSizeCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-typedef void (* GLFWframebuffersizefun)(GLFWwindow* window, int width, int height);
-
-/*! @brief The function pointer type for window content scale callbacks.
- *
- *  This is the function pointer type for window content scale callbacks.
- *  A window content scale callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, float xscale, float yscale)
- *  @endcode
- *
- *  @param[in] window The window whose content scale changed.
- *  @param[in] xscale The new x-axis content scale of the window.
- *  @param[in] yscale The new y-axis content scale of the window.
- *
- *  @sa @ref window_scale
- *  @sa @ref glfwSetWindowContentScaleCallback
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-typedef void (* GLFWwindowcontentscalefun)(GLFWwindow* window, float xscale, float yscale);
-
-/*! @brief The function pointer type for mouse button callbacks.
- *
- *  This is the function pointer type for mouse button callback functions.
- *  A mouse button callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int button, int action, int mods)
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] button The [mouse button](@ref buttons) that was pressed or
- *  released.
- *  @param[in] action One of `GLFW_PRESS` or `GLFW_RELEASE`.  Future releases
- *  may add more actions.
- *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
- *  held down.
- *
- *  @sa @ref input_mouse_button
- *  @sa @ref glfwSetMouseButtonCallback
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle and modifier mask parameters.
- *
- *  @ingroup input
- */
-typedef void (* GLFWmousebuttonfun)(GLFWwindow* window, int button, int action, int mods);
-
-/*! @brief The function pointer type for cursor position callbacks.
- *
- *  This is the function pointer type for cursor position callbacks.  A cursor
- *  position callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, double xpos, double ypos);
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] xpos The new cursor x-coordinate, relative to the left edge of
- *  the content area.
- *  @param[in] ypos The new cursor y-coordinate, relative to the top edge of the
- *  content area.
- *
- *  @sa @ref cursor_pos
- *  @sa @ref glfwSetCursorPosCallback
- *
- *  @since Added in version 3.0.  Replaces `GLFWmouseposfun`.
- *
- *  @ingroup input
- */
-typedef void (* GLFWcursorposfun)(GLFWwindow* window, double xpos, double ypos);
-
-/*! @brief The function pointer type for cursor enter/leave callbacks.
- *
- *  This is the function pointer type for cursor enter/leave callbacks.
- *  A cursor enter/leave callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int entered)
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] entered `GLFW_TRUE` if the cursor entered the window's content
- *  area, or `GLFW_FALSE` if it left it.
- *
- *  @sa @ref cursor_enter
- *  @sa @ref glfwSetCursorEnterCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup input
- */
-typedef void (* GLFWcursorenterfun)(GLFWwindow* window, int entered);
-
-/*! @brief The function pointer type for scroll callbacks.
- *
- *  This is the function pointer type for scroll callbacks.  A scroll callback
- *  function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, double xoffset, double yoffset)
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] xoffset The scroll offset along the x-axis.
- *  @param[in] yoffset The scroll offset along the y-axis.
- *
- *  @sa @ref scrolling
- *  @sa @ref glfwSetScrollCallback
- *
- *  @since Added in version 3.0.  Replaces `GLFWmousewheelfun`.
- *
- *  @ingroup input
- */
-typedef void (* GLFWscrollfun)(GLFWwindow* window, double xoffset, double yoffset);
-
-/*! @brief The function pointer type for keyboard key callbacks.
- *
- *  This is the function pointer type for keyboard key callbacks.  A keyboard
- *  key callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] key The [keyboard key](@ref keys) that was pressed or released.
- *  @param[in] scancode The system-specific scancode of the key.
- *  @param[in] action `GLFW_PRESS`, `GLFW_RELEASE` or `GLFW_REPEAT`.  Future
- *  releases may add more actions.
- *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
- *  held down.
- *
- *  @sa @ref input_key
- *  @sa @ref glfwSetKeyCallback
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle, scancode and modifier mask parameters.
- *
- *  @ingroup input
- */
-typedef void (* GLFWkeyfun)(GLFWwindow* window, int key, int scancode, int action, int mods);
-
-/*! @brief The function pointer type for Unicode character callbacks.
- *
- *  This is the function pointer type for Unicode character callbacks.
- *  A Unicode character callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, unsigned int codepoint)
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] codepoint The Unicode code point of the character.
- *
- *  @sa @ref input_char
- *  @sa @ref glfwSetCharCallback
- *
- *  @since Added in version 2.4.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup input
- */
-typedef void (* GLFWcharfun)(GLFWwindow* window, unsigned int codepoint);
-
-/*! @brief The function pointer type for Unicode character with modifiers
- *  callbacks.
- *
- *  This is the function pointer type for Unicode character with modifiers
- *  callbacks.  It is called for each input character, regardless of what
- *  modifier keys are held down.  A Unicode character with modifiers callback
- *  function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, unsigned int codepoint, int mods)
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] codepoint The Unicode code point of the character.
- *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
- *  held down.
- *
- *  @sa @ref input_char
- *  @sa @ref glfwSetCharModsCallback
- *
- *  @deprecated Scheduled for removal in version 4.0.
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-typedef void (* GLFWcharmodsfun)(GLFWwindow* window, unsigned int codepoint, int mods);
-
-/*! @brief The function pointer type for path drop callbacks.
- *
- *  This is the function pointer type for path drop callbacks.  A path drop
- *  callback function has the following signature:
- *  @code
- *  void function_name(GLFWwindow* window, int path_count, const char* paths[])
- *  @endcode
- *
- *  @param[in] window The window that received the event.
- *  @param[in] path_count The number of dropped paths.
- *  @param[in] paths The UTF-8 encoded file and/or directory path names.
- *
- *  @pointer_lifetime The path array and its strings are valid until the
- *  callback function returns.
- *
- *  @sa @ref path_drop
- *  @sa @ref glfwSetDropCallback
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-typedef void (* GLFWdropfun)(GLFWwindow* window, int path_count, const char* paths[]);
-
-/*! @brief The function pointer type for monitor configuration callbacks.
- *
- *  This is the function pointer type for monitor configuration callbacks.
- *  A monitor callback function has the following signature:
- *  @code
- *  void function_name(GLFWmonitor* monitor, int event)
- *  @endcode
- *
- *  @param[in] monitor The monitor that was connected or disconnected.
- *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
- *  releases may add more events.
- *
- *  @sa @ref monitor_event
- *  @sa @ref glfwSetMonitorCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-typedef void (* GLFWmonitorfun)(GLFWmonitor* monitor, int event);
-
-/*! @brief The function pointer type for joystick configuration callbacks.
- *
- *  This is the function pointer type for joystick configuration callbacks.
- *  A joystick configuration callback function has the following signature:
- *  @code
- *  void function_name(int jid, int event)
- *  @endcode
- *
- *  @param[in] jid The joystick that was connected or disconnected.
- *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
- *  releases may add more events.
- *
- *  @sa @ref joystick_event
- *  @sa @ref glfwSetJoystickCallback
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup input
- */
-typedef void (* GLFWjoystickfun)(int jid, int event);
-
-/*! @brief Video mode type.
- *
- *  This describes a single video mode.
- *
- *  @sa @ref monitor_modes
- *  @sa @ref glfwGetVideoMode
- *  @sa @ref glfwGetVideoModes
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added refresh rate member.
- *
- *  @ingroup monitor
- */
-typedef struct GLFWvidmode
-{
-    /*! The width, in screen coordinates, of the video mode.
+    /*! @brief Client API function pointer type.
+     *
+     *  Generic function pointer used for returning client API function pointers
+     *  without forcing a cast from a regular pointer.
+     *
+     *  @sa @ref context_glext
+     *  @sa @ref glfwGetProcAddress
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup context
      */
-    int width;
-    /*! The height, in screen coordinates, of the video mode.
+    typedef void (*GLFWglproc)(void);
+
+    /*! @brief Vulkan API function pointer type.
+     *
+     *  Generic function pointer used for returning Vulkan API function pointers
+     *  without forcing a cast from a regular pointer.
+     *
+     *  @sa @ref vulkan_proc
+     *  @sa @ref glfwGetInstanceProcAddress
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup vulkan
      */
-    int height;
-    /*! The bit depth of the red channel of the video mode.
+    typedef void (*GLFWvkproc)(void);
+
+    /*! @brief Opaque monitor object.
+     *
+     *  Opaque monitor object.
+     *
+     *  @see @ref monitor_object
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
      */
-    int redBits;
-    /*! The bit depth of the green channel of the video mode.
+    typedef struct GLFWmonitor GLFWmonitor;
+
+    /*! @brief Opaque window object.
+     *
+     *  Opaque window object.
+     *
+     *  @see @ref window_object
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
      */
-    int greenBits;
-    /*! The bit depth of the blue channel of the video mode.
+    typedef struct GLFWwindow GLFWwindow;
+
+    /*! @brief Opaque user OpenGL & OpenGL ES context object.
+     *
+     *  Opaque user OpenGL OpenGL ES context object.
+     *
+     *  @see @ref context_user
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup window
      */
-    int blueBits;
-    /*! The refresh rate, in Hz, of the video mode.
+    typedef struct GLFWusercontext GLFWusercontext;
+
+    /*! @brief Opaque cursor object.
+     *
+     *  Opaque cursor object.
+     *
+     *  @see @ref cursor_object
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
      */
-    int refreshRate;
-} GLFWvidmode;
+    typedef struct GLFWcursor GLFWcursor;
 
-/*! @brief Gamma ramp.
- *
- *  This describes the gamma ramp for a monitor.
- *
- *  @sa @ref monitor_gamma
- *  @sa @ref glfwGetGammaRamp
- *  @sa @ref glfwSetGammaRamp
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-typedef struct GLFWgammaramp
-{
-    /*! An array of value describing the response of the red channel.
+    /*! @brief The function pointer type for memory allocation callbacks.
+     *
+     *  This is the function pointer type for memory allocation callbacks.  A memory
+     *  allocation callback function has the following signature:
+     *  @code
+     *  void* function_name(size_t size, void* user)
+     *  @endcode
+     *
+     *  This function must return either a memory block at least `size` bytes long,
+     *  or `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
+     *  failures gracefully yet.
+     *
+     *  This function may be called during @ref glfwInit but before the library is
+     *  flagged as initialized, as well as during @ref glfwTerminate after the
+     *  library is no longer flagged as initialized.
+     *
+     *  Any memory allocated by this function will be deallocated during library
+     *  termination or earlier.
+     *
+     *  The size will always be greater than zero.  Allocations of size zero are filtered out
+     *  before reaching the custom allocator.
+     *
+     *  @param[in] size The minimum size, in bytes, of the memory block.
+     *  @param[in] user The user-defined pointer from the allocator.
+     *  @return The address of the newly allocated memory block, or `NULL` if an
+     *  error occurred.
+     *
+     *  @pointer_lifetime The returned memory block must be valid at least until it
+     *  is deallocated.
+     *
+     *  @reentrancy This function should not call any GLFW function.
+     *
+     *  @thread_safety This function may be called from any thread that calls GLFW functions.
+     *
+     *  @sa @ref init_allocator
+     *  @sa @ref GLFWallocator
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup init
      */
-    unsigned short* red;
-    /*! An array of value describing the response of the green channel.
+    typedef void *(*GLFWallocatefun)(size_t size, void *user);
+
+    /*! @brief The function pointer type for memory reallocation callbacks.
+     *
+     *  This is the function pointer type for memory reallocation callbacks.
+     *  A memory reallocation callback function has the following signature:
+     *  @code
+     *  void* function_name(void* block, size_t size, void* user)
+     *  @endcode
+     *
+     *  This function must return a memory block at least `size` bytes long, or
+     *  `NULL` if allocation failed.  Note that not all parts of GLFW handle allocation
+     *  failures gracefully yet.
+     *
+     *  This function may be called during @ref glfwInit but before the library is
+     *  flagged as initialized, as well as during @ref glfwTerminate after the
+     *  library is no longer flagged as initialized.
+     *
+     *  Any memory allocated by this function will be deallocated during library
+     *  termination or earlier.
+     *
+     *  The block address will never be `NULL` and the size will always be greater than zero.
+     *  Reallocations of a block to size zero are converted into deallocations.  Reallocations
+     *  of `NULL` to a non-zero size are converted into regular allocations.
+     *
+     *  @param[in] block The address of the memory block to reallocate.
+     *  @param[in] size The new minimum size, in bytes, of the memory block.
+     *  @param[in] user The user-defined pointer from the allocator.
+     *  @return The address of the newly allocated or resized memory block, or
+     *  `NULL` if an error occurred.
+     *
+     *  @pointer_lifetime The returned memory block must be valid at least until it
+     *  is deallocated.
+     *
+     *  @reentrancy This function should not call any GLFW function.
+     *
+     *  @thread_safety This function may be called from any thread that calls GLFW functions.
+     *
+     *  @sa @ref init_allocator
+     *  @sa @ref GLFWallocator
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup init
      */
-    unsigned short* green;
-    /*! An array of value describing the response of the blue channel.
+    typedef void *(*GLFWreallocatefun)(void *block, size_t size, void *user);
+
+    /*! @brief The function pointer type for memory deallocation callbacks.
+     *
+     *  This is the function pointer type for memory deallocation callbacks.
+     *  A memory deallocation callback function has the following signature:
+     *  @code
+     *  void function_name(void* block, void* user)
+     *  @endcode
+     *
+     *  This function may deallocate the specified memory block.  This memory block
+     *  will have been allocated with the same allocator.
+     *
+     *  This function may be called during @ref glfwInit but before the library is
+     *  flagged as initialized, as well as during @ref glfwTerminate after the
+     *  library is no longer flagged as initialized.
+     *
+     *  The block address will never be `NULL`.  Deallocations of `NULL` are filtered out
+     *  before reaching the custom allocator.
+     *
+     *  @param[in] block The address of the memory block to deallocate.
+     *  @param[in] user The user-defined pointer from the allocator.
+     *
+     *  @pointer_lifetime The specified memory block will not be accessed by GLFW
+     *  after this function is called.
+     *
+     *  @reentrancy This function should not call any GLFW function.
+     *
+     *  @thread_safety This function may be called from any thread that calls GLFW functions.
+     *
+     *  @sa @ref init_allocator
+     *  @sa @ref GLFWallocator
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup init
      */
-    unsigned short* blue;
-    /*! The number of elements in each array.
+    typedef void (*GLFWdeallocatefun)(void *block, void *user);
+
+    /*! @brief The function pointer type for error callbacks.
+     *
+     *  This is the function pointer type for error callbacks.  An error callback
+     *  function has the following signature:
+     *  @code
+     *  void callback_name(int error_code, const char* description)
+     *  @endcode
+     *
+     *  @param[in] error_code An [error code](@ref errors).  Future releases may add
+     *  more error codes.
+     *  @param[in] description A UTF-8 encoded string describing the error.
+     *
+     *  @pointer_lifetime The error description string is valid until the callback
+     *  function returns.
+     *
+     *  @sa @ref error_handling
+     *  @sa @ref glfwSetErrorCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup init
      */
-    unsigned int size;
-} GLFWgammaramp;
+    typedef void (*GLFWerrorfun)(int error_code, const char *description);
 
-/*! @brief Image data.
- *
- *  This describes a single 2D image.  See the documentation for each related
- *  function what the expected pixel format is.
- *
- *  @sa @ref cursor_custom
- *  @sa @ref window_icon
- *
- *  @since Added in version 2.1.
- *  @glfw3 Removed format and bytes-per-pixel members.
- *
- *  @ingroup window
- */
-typedef struct GLFWimage
-{
-    /*! The width, in pixels, of this image.
+    /*! @brief The function pointer type for window position callbacks.
+     *
+     *  This is the function pointer type for window position callbacks.  A window
+     *  position callback function has the following signature:
+     *  @code
+     *  void callback_name(GLFWwindow* window, int xpos, int ypos)
+     *  @endcode
+     *
+     *  @param[in] window The window that was moved.
+     *  @param[in] xpos The new x-coordinate, in screen coordinates, of the
+     *  upper-left corner of the content area of the window.
+     *  @param[in] ypos The new y-coordinate, in screen coordinates, of the
+     *  upper-left corner of the content area of the window.
+     *
+     *  @sa @ref window_pos
+     *  @sa @ref glfwSetWindowPosCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
      */
-    int width;
-    /*! The height, in pixels, of this image.
+    typedef void (*GLFWwindowposfun)(GLFWwindow *window, int xpos, int ypos);
+
+    /*! @brief The function pointer type for window size callbacks.
+     *
+     *  This is the function pointer type for window size callbacks.  A window size
+     *  callback function has the following signature:
+     *  @code
+     *  void callback_name(GLFWwindow* window, int width, int height)
+     *  @endcode
+     *
+     *  @param[in] window The window that was resized.
+     *  @param[in] width The new width, in screen coordinates, of the window.
+     *  @param[in] height The new height, in screen coordinates, of the window.
+     *
+     *  @sa @ref window_size
+     *  @sa @ref glfwSetWindowSizeCallback
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
      */
-    int height;
-    /*! The pixel data of this image, arranged left-to-right, top-to-bottom.
+    typedef void (*GLFWwindowsizefun)(GLFWwindow *window, int width, int height);
+
+    /*! @brief The function pointer type for window close callbacks.
+     *
+     *  This is the function pointer type for window close callbacks.  A window
+     *  close callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window)
+     *  @endcode
+     *
+     *  @param[in] window The window that the user attempted to close.
+     *
+     *  @sa @ref window_close
+     *  @sa @ref glfwSetWindowCloseCallback
+     *
+     *  @since Added in version 2.5.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
      */
-    unsigned char* pixels;
-} GLFWimage;
+    typedef void (*GLFWwindowclosefun)(GLFWwindow *window);
 
-/*! @brief Gamepad input state
- *
- *  This describes the input state of a gamepad.
- *
- *  @sa @ref gamepad
- *  @sa @ref glfwGetGamepadState
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-typedef struct GLFWgamepadstate
-{
-    /*! The states of each [gamepad button](@ref gamepad_buttons), `GLFW_PRESS`
-     *  or `GLFW_RELEASE`.
+    /*! @brief The function pointer type for window content refresh callbacks.
+     *
+     *  This is the function pointer type for window content refresh callbacks.
+     *  A window content refresh callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window);
+     *  @endcode
+     *
+     *  @param[in] window The window whose content needs to be refreshed.
+     *
+     *  @sa @ref window_refresh
+     *  @sa @ref glfwSetWindowRefreshCallback
+     *
+     *  @since Added in version 2.5.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
      */
-    unsigned char buttons[15];
-    /*! The states of each [gamepad axis](@ref gamepad_axes), in the range -1.0
-     *  to 1.0 inclusive.
+    typedef void (*GLFWwindowrefreshfun)(GLFWwindow *window);
+
+    /*! @brief The function pointer type for window focus callbacks.
+     *
+     *  This is the function pointer type for window focus callbacks.  A window
+     *  focus callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int focused)
+     *  @endcode
+     *
+     *  @param[in] window The window that gained or lost input focus.
+     *  @param[in] focused `GLFW_TRUE` if the window was given input focus, or
+     *  `GLFW_FALSE` if it lost it.
+     *
+     *  @sa @ref window_focus
+     *  @sa @ref glfwSetWindowFocusCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
      */
-    float axes[6];
-} GLFWgamepadstate;
-
-/*! @brief
- *
- *  @sa @ref init_allocator
- *  @sa @ref glfwInitAllocator
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup init
- */
-typedef struct GLFWallocator
-{
-    GLFWallocatefun allocate;
-    GLFWreallocatefun reallocate;
-    GLFWdeallocatefun deallocate;
-    void* user;
-} GLFWallocator;
-
-
-/*************************************************************************
- * GLFW API functions
- *************************************************************************/
-
-/*! @brief Initializes the GLFW library.
- *
- *  This function initializes the GLFW library.  Before most GLFW functions can
- *  be used, GLFW must be initialized, and before an application terminates GLFW
- *  should be terminated in order to free any resources allocated during or
- *  after initialization.
- *
- *  If this function fails, it calls @ref glfwTerminate before returning.  If it
- *  succeeds, you should call @ref glfwTerminate before the application exits.
- *
- *  Additional calls to this function after successful initialization but before
- *  termination will return `GLFW_TRUE` immediately.
- *
- *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark @macos This function will change the current directory of the
- *  application to the `Contents/Resources` subdirectory of the application's
- *  bundle, if present.  This can be disabled with the @ref
- *  GLFW_COCOA_CHDIR_RESOURCES init hint.
- *
- *  @remark @macos This function will create the main menu and dock icon for the
- *  application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
- *  contain a menu bar.  Otherwise a minimal menu bar is created manually with
- *  common commands like Hide, Quit and About.  The About entry opens a minimal
- *  about dialog with information from the application's bundle.  The menu bar
- *  and dock icon can be disabled entirely with the @ref GLFW_COCOA_MENUBAR init
- *  hint.
- *
- *  @remark @x11 This function will set the `LC_CTYPE` category of the
- *  application locale according to the current environment if that category is
- *  still "C".  This is because the "C" locale breaks Unicode text input.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref intro_init
- *  @sa @ref glfwInitHint
- *  @sa @ref glfwInitAllocator
- *  @sa @ref glfwTerminate
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup init
- */
-GLFWAPI int glfwInit(void);
-
-/*! @brief Terminates the GLFW library.
- *
- *  This function destroys all remaining windows and cursors, restores any
- *  modified gamma ramps and frees any other allocated resources.  Once this
- *  function is called, you must again call @ref glfwInit successfully before
- *  you will be able to use most GLFW functions.
- *
- *  If GLFW has been successfully initialized, this function should be called
- *  before the application exits.  If initialization fails, there is no need to
- *  call this function, as it is called by @ref glfwInit before it returns
- *  failure.
- *
- *  This function has no effect if GLFW is not initialized.
- *
- *  @errors Possible errors include @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark This function may be called before @ref glfwInit.
- *
- *  @warning The contexts of any remaining windows must not be current on any
- *  other thread when this function is called.
- *
- *  @reentrancy This function must not be called from a callback.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref intro_init
- *  @sa @ref glfwInit
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup init
- */
-GLFWAPI void glfwTerminate(void);
-
-/*! @brief Sets the specified init hint to the desired value.
- *
- *  This function sets hints for the next initialization of GLFW.
- *
- *  The values you set hints to are never reset by GLFW, but they only take
- *  effect during initialization.  Once GLFW has been initialized, any values
- *  you set will be ignored until the library is terminated and initialized
- *  again.
- *
- *  Some hints are platform specific.  These may be set on any platform but they
- *  will only affect their specific platform.  Other platforms will ignore them.
- *  Setting these hints requires no platform specific headers or functions.
- *
- *  @param[in] hint The [init hint](@ref init_hints) to set.
- *  @param[in] value The new value of the init hint.
- *
- *  @errors Possible errors include @ref GLFW_INVALID_ENUM and @ref
- *  GLFW_INVALID_VALUE.
- *
- *  @remarks This function may be called before @ref glfwInit.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa init_hints
- *  @sa glfwInit
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup init
- */
-GLFWAPI void glfwInitHint(int hint, int value);
-
-/*! @brief Sets the init allocator to the desired value.
- *
- *  To use the default allocator, call this function with a `NULL` argument.
- *
- *  If you specify an allocator struct, every member must be a valid function
- *  pointer.  If any member is `NULL`, this function emits @ref
- *  GLFW_INVALID_VALUE and the init allocator is unchanged.
- *
- *  @param[in] allocator The allocator to use at the next initialization, or
- *  `NULL` to use the default one.
- *
- *  @errors Possible errors include @ref GLFW_INVALID_VALUE.
- *
- *  @pointer_lifetime The specified allocator is copied before this function
- *  returns.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref init_allocator
- *  @sa @ref glfwInit
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup init
- */
-GLFWAPI void glfwInitAllocator(const GLFWallocator* allocator);
-
-/*! @brief Retrieves the version of the GLFW library.
- *
- *  This function retrieves the major, minor and revision numbers of the GLFW
- *  library.  It is intended for when you are using GLFW as a shared library and
- *  want to ensure that you are using the minimum required version.
- *
- *  Any or all of the version arguments may be `NULL`.
- *
- *  @param[out] major Where to store the major version number, or `NULL`.
- *  @param[out] minor Where to store the minor version number, or `NULL`.
- *  @param[out] rev Where to store the revision number, or `NULL`.
- *
- *  @errors None.
- *
- *  @remark This function may be called before @ref glfwInit.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref intro_version
- *  @sa @ref glfwGetVersionString
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup init
- */
-GLFWAPI void glfwGetVersion(int* major, int* minor, int* rev);
-
-/*! @brief Returns a string describing the compile-time configuration.
- *
- *  This function returns the compile-time generated
- *  [version string](@ref intro_version_string) of the GLFW library binary.  It
- *  describes the version, platform, compiler and any platform-specific
- *  compile-time options.  It should not be confused with the OpenGL or OpenGL
- *  ES version string, queried with `glGetString`.
- *
- *  __Do not use the version string__ to parse the GLFW library version.  The
- *  @ref glfwGetVersion function provides the version of the running library
- *  binary in numerical format.
- *
- *  @return The ASCII encoded GLFW version string.
- *
- *  @errors None.
- *
- *  @remark This function may be called before @ref glfwInit.
- *
- *  @pointer_lifetime The returned string is static and compile-time generated.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref intro_version
- *  @sa @ref glfwGetVersion
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup init
- */
-GLFWAPI const char* glfwGetVersionString(void);
-
-/*! @brief Returns and clears the last error for the calling thread.
- *
- *  This function returns and clears the [error code](@ref errors) of the last
- *  error that occurred on the calling thread, and optionally a UTF-8 encoded
- *  human-readable description of it.  If no error has occurred since the last
- *  call, it returns @ref GLFW_NO_ERROR (zero) and the description pointer is
- *  set to `NULL`.
- *
- *  @param[in] description Where to store the error description pointer, or `NULL`.
- *  @return The last error code for the calling thread, or @ref GLFW_NO_ERROR
- *  (zero).
- *
- *  @errors None.
- *
- *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is guaranteed to be valid only until the
- *  next error occurs or the library is terminated.
- *
- *  @remark This function may be called before @ref glfwInit.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref error_handling
- *  @sa @ref glfwSetErrorCallback
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup init
- */
-GLFWAPI int glfwGetError(const char** description);
-
-/*! @brief Sets the error callback.
- *
- *  This function sets the error callback, which is called with an error code
- *  and a human-readable description each time a GLFW error occurs.
- *
- *  The error code is set before the callback is called.  Calling @ref
- *  glfwGetError from the error callback will return the same value as the error
- *  code argument.
- *
- *  The error callback is called on the thread where the error occurred.  If you
- *  are using GLFW from multiple threads, your error callback needs to be
- *  written accordingly.
- *
- *  Because the description string may have been generated specifically for that
- *  error, it is not guaranteed to be valid after the callback has returned.  If
- *  you wish to use it after the callback returns, you need to make a copy.
- *
- *  Once set, the error callback remains set even after the library has been
- *  terminated.
- *
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set.
- *
- *  @callback_signature
- *  @code
- *  void callback_name(int error_code, const char* description)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [callback pointer type](@ref GLFWerrorfun).
- *
- *  @errors None.
- *
- *  @remark This function may be called before @ref glfwInit.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref error_handling
- *  @sa @ref glfwGetError
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup init
- */
-GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun callback);
-
-/*! @brief Returns the currently connected monitors.
- *
- *  This function returns an array of handles for all currently connected
- *  monitors.  The primary monitor is always first in the returned array.  If no
- *  monitors were found, this function returns `NULL`.
- *
- *  @param[out] count Where to store the number of monitors in the returned
- *  array.  This is set to zero if an error occurred.
- *  @return An array of monitor handles, or `NULL` if no monitors were found or
- *  if an [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is guaranteed to be valid only until the
- *  monitor configuration changes or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_monitors
- *  @sa @ref monitor_event
- *  @sa @ref glfwGetPrimaryMonitor
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI GLFWmonitor** glfwGetMonitors(int* count);
-
-/*! @brief Returns the primary monitor.
- *
- *  This function returns the primary monitor.  This is usually the monitor
- *  where elements like the task bar or global menu bar are located.
- *
- *  @return The primary monitor, or `NULL` if no monitors were found or if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @remark The primary monitor is always first in the array returned by @ref
- *  glfwGetMonitors.
- *
- *  @sa @ref monitor_monitors
- *  @sa @ref glfwGetMonitors
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void);
-
-/*! @brief Returns the position of the monitor's viewport on the virtual screen.
- *
- *  This function returns the position, in screen coordinates, of the upper-left
- *  corner of the specified monitor.
- *
- *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
- *  non-`NULL` position arguments will be set to zero.
- *
- *  @param[in] monitor The monitor to query.
- *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
- *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_properties
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
-
-/*! @brief Retrieves the work area of the monitor.
- *
- *  This function returns the position, in screen coordinates, of the upper-left
- *  corner of the work area of the specified monitor along with the work area
- *  size in screen coordinates. The work area is defined as the area of the
- *  monitor not occluded by the operating system task bar where present. If no
- *  task bar exists then the work area is the monitor resolution in screen
- *  coordinates.
- *
- *  Any or all of the position and size arguments may be `NULL`.  If an error
- *  occurs, all non-`NULL` position and size arguments will be set to zero.
- *
- *  @param[in] monitor The monitor to query.
- *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
- *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
- *  @param[out] width Where to store the monitor width, or `NULL`.
- *  @param[out] height Where to store the monitor height, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_workarea
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup monitor
- */
-GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor* monitor, int* xpos, int* ypos, int* width, int* height);
-
-/*! @brief Returns the physical size of the monitor.
- *
- *  This function returns the size, in millimetres, of the display area of the
- *  specified monitor.
- *
- *  Some systems do not provide accurate monitor size information, either
- *  because the monitor
- *  [EDID](https://en.wikipedia.org/wiki/Extended_display_identification_data)
- *  data is incorrect or because the driver does not report it accurately.
- *
- *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
- *  non-`NULL` size arguments will be set to zero.
- *
- *  @param[in] monitor The monitor to query.
- *  @param[out] widthMM Where to store the width, in millimetres, of the
- *  monitor's display area, or `NULL`.
- *  @param[out] heightMM Where to store the height, in millimetres, of the
- *  monitor's display area, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @remark @win32 calculates the returned physical size from the
- *  current resolution and system DPI instead of querying the monitor EDID data.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_properties
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* widthMM, int* heightMM);
-
-/*! @brief Retrieves the content scale for the specified monitor.
- *
- *  This function retrieves the content scale for the specified monitor.  The
- *  content scale is the ratio between the current DPI and the platform's
- *  default DPI.  This is especially important for text and any UI elements.  If
- *  the pixel dimensions of your UI scaled by this look appropriate on your
- *  machine then it should appear at a reasonable size on other machines
- *  regardless of their DPI and scaling settings.  This relies on the system DPI
- *  and scaling settings being somewhat correct.
- *
- *  The content scale may depend on both the monitor resolution and pixel
- *  density and on user settings.  It may be very different from the raw DPI
- *  calculated from the physical size and current resolution.
- *
- *  @param[in] monitor The monitor to query.
- *  @param[out] xscale Where to store the x-axis content scale, or `NULL`.
- *  @param[out] yscale Where to store the y-axis content scale, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_scale
- *  @sa @ref glfwGetWindowContentScale
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup monitor
- */
-GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor* monitor, float* xscale, float* yscale);
-
-/*! @brief Returns the name of the specified monitor.
- *
- *  This function returns a human-readable name, encoded as UTF-8, of the
- *  specified monitor.  The name typically reflects the make and model of the
- *  monitor and is not guaranteed to be unique among the connected monitors.
- *
- *  @param[in] monitor The monitor to query.
- *  @return The UTF-8 encoded name of the monitor, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified monitor is
- *  disconnected or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_properties
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI const char* glfwGetMonitorName(GLFWmonitor* monitor);
-
-/*! @brief Sets the user pointer of the specified monitor.
- *
- *  This function sets the user-defined pointer of the specified monitor.  The
- *  current value is retained until the monitor is disconnected.  The initial
- *  value is `NULL`.
- *
- *  This function may be called from the monitor callback, even for a monitor
- *  that is being disconnected.
- *
- *  @param[in] monitor The monitor whose pointer to set.
- *  @param[in] pointer The new value.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref monitor_userptr
- *  @sa @ref glfwGetMonitorUserPointer
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup monitor
- */
-GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor* monitor, void* pointer);
-
-/*! @brief Returns the user pointer of the specified monitor.
- *
- *  This function returns the current value of the user-defined pointer of the
- *  specified monitor.  The initial value is `NULL`.
- *
- *  This function may be called from the monitor callback, even for a monitor
- *  that is being disconnected.
- *
- *  @param[in] monitor The monitor whose pointer to return.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref monitor_userptr
- *  @sa @ref glfwSetMonitorUserPointer
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup monitor
- */
-GLFWAPI void* glfwGetMonitorUserPointer(GLFWmonitor* monitor);
-
-/*! @brief Sets the monitor configuration callback.
- *
- *  This function sets the monitor configuration callback, or removes the
- *  currently set callback.  This is called when a monitor is connected to or
- *  disconnected from the system.
- *
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWmonitor* monitor, int event)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWmonitorfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_event
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI GLFWmonitorfun glfwSetMonitorCallback(GLFWmonitorfun callback);
-
-/*! @brief Returns the available video modes for the specified monitor.
- *
- *  This function returns an array of all video modes supported by the specified
- *  monitor.  The returned array is sorted in ascending order, first by color
- *  bit depth (the sum of all channel depths), then by resolution area (the
- *  product of width and height), then resolution width and finally by refresh
- *  rate.
- *
- *  @param[in] monitor The monitor to query.
- *  @param[out] count Where to store the number of video modes in the returned
- *  array.  This is set to zero if an error occurred.
- *  @return An array of video modes, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified monitor is
- *  disconnected, this function is called again for that monitor or the library
- *  is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_modes
- *  @sa @ref glfwGetVideoMode
- *
- *  @since Added in version 1.0.
- *  @glfw3 Changed to return an array of modes for a specific monitor.
- *
- *  @ingroup monitor
- */
-GLFWAPI const GLFWvidmode* glfwGetVideoModes(GLFWmonitor* monitor, int* count);
-
-/*! @brief Returns the current mode of the specified monitor.
- *
- *  This function returns the current video mode of the specified monitor.  If
- *  you have created a full screen window for that monitor, the return value
- *  will depend on whether that window is iconified.
- *
- *  @param[in] monitor The monitor to query.
- *  @return The current mode of the monitor, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified monitor is
- *  disconnected or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_modes
- *  @sa @ref glfwGetVideoModes
- *
- *  @since Added in version 3.0.  Replaces `glfwGetDesktopMode`.
- *
- *  @ingroup monitor
- */
-GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
-
-/*! @brief Generates a gamma ramp and sets it for the specified monitor.
- *
- *  This function generates an appropriately sized gamma ramp from the specified
- *  exponent and then calls @ref glfwSetGammaRamp with it.  The value must be
- *  a finite number greater than zero.
- *
- *  The software controlled gamma ramp is applied _in addition_ to the hardware
- *  gamma correction, which today is usually an approximation of sRGB gamma.
- *  This means that setting a perfectly linear ramp, or gamma 1.0, will produce
- *  the default (usually sRGB-like) behavior.
- *
- *  For gamma correct rendering with OpenGL or OpenGL ES, see the @ref
- *  GLFW_SRGB_CAPABLE hint.
- *
- *  @param[in] monitor The monitor whose gamma ramp to set.
- *  @param[in] gamma The desired exponent.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark @wayland Gamma handling is a privileged protocol, this function
- *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_gamma
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
-
-/*! @brief Returns the current gamma ramp for the specified monitor.
- *
- *  This function returns the current gamma ramp of the specified monitor.
- *
- *  @param[in] monitor The monitor to query.
- *  @return The current gamma ramp, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @wayland Gamma handling is a privileged protocol, this function
- *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR while
- *  returning `NULL`.
- *
- *  @pointer_lifetime The returned structure and its arrays are allocated and
- *  freed by GLFW.  You should not free them yourself.  They are valid until the
- *  specified monitor is disconnected, this function is called again for that
- *  monitor or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_gamma
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
-
-/*! @brief Sets the current gamma ramp for the specified monitor.
- *
- *  This function sets the current gamma ramp for the specified monitor.  The
- *  original gamma ramp for that monitor is saved by GLFW the first time this
- *  function is called and is restored by @ref glfwTerminate.
- *
- *  The software controlled gamma ramp is applied _in addition_ to the hardware
- *  gamma correction, which today is usually an approximation of sRGB gamma.
- *  This means that setting a perfectly linear ramp, or gamma 1.0, will produce
- *  the default (usually sRGB-like) behavior.
- *
- *  For gamma correct rendering with OpenGL or OpenGL ES, see the @ref
- *  GLFW_SRGB_CAPABLE hint.
- *
- *  @param[in] monitor The monitor whose gamma ramp to set.
- *  @param[in] ramp The gamma ramp to use.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark The size of the specified gamma ramp should match the size of the
- *  current ramp for that monitor.
- *
- *  @remark @win32 The gamma ramp size must be 256.
- *
- *  @remark @wayland Gamma handling is a privileged protocol, this function
- *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The specified gamma ramp is copied before this function
- *  returns.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref monitor_gamma
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup monitor
- */
-GLFWAPI void glfwSetGammaRamp(GLFWmonitor* monitor, const GLFWgammaramp* ramp);
-
-/*! @brief Resets all window hints to their default values.
- *
- *  This function resets all window hints to their
- *  [default values](@ref window_hints_values).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_hints
- *  @sa @ref glfwWindowHint
- *  @sa @ref glfwWindowHintString
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwDefaultWindowHints(void);
-
-/*! @brief Sets the specified window hint to the desired value.
- *
- *  This function sets hints for the next call to @ref glfwCreateWindow.  The
- *  hints, once set, retain their values until changed by a call to this
- *  function or @ref glfwDefaultWindowHints, or until the library is terminated.
- *
- *  Only integer value hints can be set with this function.  String value hints
- *  are set with @ref glfwWindowHintString.
- *
- *  This function does not check whether the specified hint values are valid.
- *  If you set hints to invalid values this will instead be reported by the next
- *  call to @ref glfwCreateWindow.
- *
- *  Some hints are platform specific.  These may be set on any platform but they
- *  will only affect their specific platform.  Other platforms will ignore them.
- *  Setting these hints requires no platform specific headers or functions.
- *
- *  @param[in] hint The [window hint](@ref window_hints) to set.
- *  @param[in] value The new value of the window hint.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_hints
- *  @sa @ref glfwWindowHintString
- *  @sa @ref glfwDefaultWindowHints
- *
- *  @since Added in version 3.0.  Replaces `glfwOpenWindowHint`.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwWindowHint(int hint, int value);
-
-/*! @brief Sets the specified window hint to the desired pointer value.
- *
- *  This function works in the same way as @ref glfwWindowHint, but sets pointer
- *  values rather than integers.  Calling this function for hints that do not
- *  expect a pointer value is an error.
- *
- *  @param[in] hint The pointer [window hint](@ref window_hints) to set.
- *  @param[in] value The pointer value of the window hint.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_hints
- *  @sa @ref glfwDefaultWindowHints
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwWindowHintPointer(int hint, void* value);
-
-/*! @brief Sets the specified window hint to the desired value.
- *
- *  This function sets hints for the next call to @ref glfwCreateWindow.  The
- *  hints, once set, retain their values until changed by a call to this
- *  function or @ref glfwDefaultWindowHints, or until the library is terminated.
- *
- *  Only string type hints can be set with this function.  Integer value hints
- *  are set with @ref glfwWindowHint.
- *
- *  This function does not check whether the specified hint values are valid.
- *  If you set hints to invalid values this will instead be reported by the next
- *  call to @ref glfwCreateWindow.
- *
- *  Some hints are platform specific.  These may be set on any platform but they
- *  will only affect their specific platform.  Other platforms will ignore them.
- *  Setting these hints requires no platform specific headers or functions.
- *
- *  @param[in] hint The [window hint](@ref window_hints) to set.
- *  @param[in] value The new value of the window hint.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @pointer_lifetime The specified string is copied before this function
- *  returns.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_hints
- *  @sa @ref glfwWindowHint
- *  @sa @ref glfwDefaultWindowHints
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwWindowHintString(int hint, const char* value);
-
-/*! @brief Creates a window and its associated context.
- *
- *  This function creates a window and its associated OpenGL or OpenGL ES
- *  context.  Most of the options controlling how the window and its context
- *  should be created are specified with [window hints](@ref window_hints).
- *
- *  Successful creation does not change which context is current.  Before you
- *  can use the newly created context, you need to
- *  [make it current](@ref context_current).  For information about the `share`
- *  parameter, see @ref context_sharing.
- *
- *  The created window, framebuffer and context may differ from what you
- *  requested, as not all parameters and hints are
- *  [hard constraints](@ref window_hints_hard).  This includes the size of the
- *  window, especially for full screen windows.  To query the actual attributes
- *  of the created window, framebuffer and context, see @ref
- *  glfwGetWindowAttrib, @ref glfwGetWindowSize and @ref glfwGetFramebufferSize.
- *
- *  To create a full screen window, you need to specify the monitor the window
- *  will cover.  If no monitor is specified, the window will be windowed mode.
- *  Unless you have a way for the user to choose a specific monitor, it is
- *  recommended that you pick the primary monitor.  For more information on how
- *  to query connected monitors, see @ref monitor_monitors.
- *
- *  For full screen windows, the specified size becomes the resolution of the
- *  window's _desired video mode_.  As long as a full screen window is not
- *  iconified, the supported video mode most closely matching the desired video
- *  mode is set for the specified monitor.  For more information about full
- *  screen windows, including the creation of so called _windowed full screen_
- *  or _borderless full screen_ windows, see @ref window_windowed_full_screen.
- *
- *  Once you have created the window, you can switch it between windowed and
- *  full screen mode with @ref glfwSetWindowMonitor.  This will not affect its
- *  OpenGL or OpenGL ES context.
- *
- *  By default, newly created windows use the placement recommended by the
- *  window system.  To create the window at a specific position, make it
- *  initially invisible using the [GLFW_VISIBLE](@ref GLFW_VISIBLE_hint) window
- *  hint, set its [position](@ref window_pos) and then [show](@ref window_hide)
- *  it.
- *
- *  As long as at least one full screen window is not iconified, the screensaver
- *  is prohibited from starting.
- *
- *  Window systems put limits on window sizes.  Very large or very small window
- *  dimensions may be overridden by the window system on creation.  Check the
- *  actual [size](@ref window_size) after creation.
- *
- *  The [swap interval](@ref buffer_swap) is not set during window creation and
- *  the initial value may vary depending on driver settings and defaults.
- *
- *  @param[in] width The desired width, in screen coordinates, of the window.
- *  This must be greater than zero.
- *  @param[in] height The desired height, in screen coordinates, of the window.
- *  This must be greater than zero.
- *  @param[in] title The initial, UTF-8 encoded window title.
- *  @param[in] monitor The monitor to use for full screen mode, or `NULL` for
- *  windowed mode.
- *  @param[in] share The window whose context to share resources with, or `NULL`
- *  to not share resources.
- *  @return The handle of the created window, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE, @ref GLFW_API_UNAVAILABLE, @ref
- *  GLFW_VERSION_UNAVAILABLE, @ref GLFW_FORMAT_UNAVAILABLE and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @win32 Window creation will fail if the Microsoft GDI software
- *  OpenGL implementation is the only one available.
- *
- *  @remark @win32 If the executable has an icon resource named `GLFW_ICON,` it
- *  will be set as the initial icon for the window.  If no such icon is present,
- *  the `IDI_APPLICATION` icon will be used instead.  To set a different icon,
- *  see @ref glfwSetWindowIcon.
- *
- *  @remark @win32 The context to share resources with must not be current on
- *  any other thread.
- *
- *  @remark @macos The OS only supports core profile contexts for OpenGL
- *  versions 3.2 and later.  Before creating an OpenGL context of version 3.2 or
- *  later you must set the [GLFW_OPENGL_PROFILE](@ref GLFW_OPENGL_PROFILE_hint)
- *  hint accordingly.  OpenGL 3.0 and 3.1 contexts are not supported at all
- *  on macOS.
- *
- *  @remark @macos The GLFW window has no icon, as it is not a document
- *  window, but the dock icon will be the same as the application bundle's icon.
- *  For more information on bundles, see the
- *  [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/)
- *  in the Mac Developer Library.
- *
- *  @remark @macos On OS X 10.10 and later the window frame will not be rendered
- *  at full resolution on Retina displays unless the
- *  [GLFW_COCOA_RETINA_FRAMEBUFFER](@ref GLFW_COCOA_RETINA_FRAMEBUFFER_hint)
- *  hint is `GLFW_TRUE` and the `NSHighResolutionCapable` key is enabled in the
- *  application bundle's `Info.plist`.  For more information, see
- *  [High Resolution Guidelines for OS X](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html)
- *  in the Mac Developer Library.  The GLFW test and example programs use
- *  a custom `Info.plist` template for this, which can be found as
- *  `CMake/Info.plist.in` in the source tree.
- *
- *  @remark @macos When activating frame autosaving with
- *  [GLFW_COCOA_FRAME_NAME](@ref GLFW_COCOA_FRAME_NAME_hint), the specified
- *  window size and position may be overridden by previously saved values.
- *
- *  @remark @x11 Some window managers will not respect the placement of
- *  initially hidden windows.
- *
- *  @remark @x11 Due to the asynchronous nature of X11, it may take a moment for
- *  a window to reach its requested state.  This means you may not be able to
- *  query the final size, position or other attributes directly after window
- *  creation.
- *
- *  @remark @x11 The class part of the `WM_CLASS` window property will by
- *  default be set to the window title passed to this function.  The instance
- *  part will use the contents of the `RESOURCE_NAME` environment variable, if
- *  present and not empty, or fall back to the window title.  Set the
- *  [GLFW_X11_CLASS_NAME](@ref GLFW_X11_CLASS_NAME_hint) and
- *  [GLFW_X11_INSTANCE_NAME](@ref GLFW_X11_INSTANCE_NAME_hint) window hints to
- *  override this.
- *
- *  @remark @wayland Compositors should implement the xdg-decoration protocol
- *  for GLFW to decorate the window properly.  If this protocol isn't
- *  supported, or if the compositor prefers client-side decorations, a very
- *  simple fallback frame will be drawn using the wp_viewporter protocol.  A
- *  compositor can still emit close, maximize or fullscreen events, using for
- *  instance a keybind mechanism.  If neither of these protocols is supported,
- *  the window won't be decorated.
- *
- *  @remark @wayland A full screen window will not attempt to change the mode,
- *  no matter what the requested size or refresh rate.
- *
- *  @remark @wayland Screensaver inhibition requires the idle-inhibit protocol
- *  to be implemented in the user's compositor.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_creation
- *  @sa @ref glfwDestroyWindow
- *
- *  @since Added in version 3.0.  Replaces `glfwOpenWindow`.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height, const char* title, GLFWmonitor* monitor, GLFWwindow* share);
-
-/*! @brief Destroys the specified window and its context.
- *
- *  This function destroys the specified window and its context.  On calling
- *  this function, no further callbacks will be called for that window.
- *
- *  If the context of the specified window is current on the main thread, it is
- *  detached before being destroyed.
- *
- *  @param[in] window The window to destroy.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @note The context of the specified window must not be current on any other
- *  thread when this function is called.
- *
- *  @reentrancy This function must not be called from a callback.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_creation
- *  @sa @ref glfwCreateWindow
- *
- *  @since Added in version 3.0.  Replaces `glfwCloseWindow`.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwDestroyWindow(GLFWwindow* window);
-
-/*! @brief Checks the close flag of the specified window.
- *
- *  This function returns the value of the close flag of the specified window.
- *
- *  @param[in] window The window to query.
- *  @return The value of the close flag.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref window_close
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI int glfwWindowShouldClose(GLFWwindow* window);
-
-/*! @brief Sets the close flag of the specified window.
- *
- *  This function sets the value of the close flag of the specified window.
- *  This can be used to override the user's attempt to close the window, or
- *  to signal that it should be closed.
- *
- *  @param[in] window The window whose flag to change.
- *  @param[in] value The new value.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref window_close
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
-
-/*! @brief Sets the title of the specified window.
- *
- *  This function sets the window title, encoded as UTF-8, of the specified
- *  window.
- *
- *  @param[in] window The window whose title to change.
- *  @param[in] title The UTF-8 encoded window title.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @macos The window title will not be updated until the next time you
- *  process events.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_title
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
-
-/*! @brief Sets the icon for the specified window.
- *
- *  This function sets the icon of the specified window.  If passed an array of
- *  candidate images, those of or closest to the sizes desired by the system are
- *  selected.  If no images are specified, the window reverts to its default
- *  icon.
- *
- *  The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
- *  bits per channel with the red channel first.  They are arranged canonically
- *  as packed sequential rows, starting from the top-left corner.
- *
- *  The desired image sizes varies depending on platform and system settings.
- *  The selected images will be rescaled as needed.  Good sizes include 16x16,
- *  32x32 and 48x48.
- *
- *  @param[in] window The window whose icon to set.
- *  @param[in] count The number of images in the specified array, or zero to
- *  revert to the default window icon.
- *  @param[in] images The images to create the icon from.  This is ignored if
- *  count is zero.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
- *
- *  @pointer_lifetime The specified image data is copied before this function
- *  returns.
- *
- *  @remark @macos Regular windows do not have icons on macOS.  This function
- *  will emit @ref GLFW_FEATURE_UNAVAILABLE.  The dock icon will be the same as
- *  the application bundle's icon.  For more information on bundles, see the
- *  [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/)
- *  in the Mac Developer Library.
- *
- *  @remark @wayland There is no existing protocol to change an icon, the
- *  window will thus inherit the one defined in the application's desktop file.
- *  This function will emit @ref GLFW_FEATURE_UNAVAILABLE.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_icon
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowIcon(GLFWwindow* window, int count, const GLFWimage* images);
-
-/*! @brief Retrieves the position of the content area of the specified window.
- *
- *  This function retrieves the position, in screen coordinates, of the
- *  upper-left corner of the content area of the specified window.
- *
- *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
- *  non-`NULL` position arguments will be set to zero.
- *
- *  @param[in] window The window to query.
- *  @param[out] xpos Where to store the x-coordinate of the upper-left corner of
- *  the content area, or `NULL`.
- *  @param[out] ypos Where to store the y-coordinate of the upper-left corner of
- *  the content area, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
- *
- *  @remark @wayland There is no way for an application to retrieve the global
- *  position of its windows.  This function will emit @ref
- *  GLFW_FEATURE_UNAVAILABLE.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_pos
- *  @sa @ref glfwSetWindowPos
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
-
-/*! @brief Sets the position of the content area of the specified window.
- *
- *  This function sets the position, in screen coordinates, of the upper-left
- *  corner of the content area of the specified windowed mode window.  If the
- *  window is a full screen window, this function does nothing.
- *
- *  __Do not use this function__ to move an already visible window unless you
- *  have very good reasons for doing so, as it will confuse and annoy the user.
- *
- *  The window manager may put limits on what positions are allowed.  GLFW
- *  cannot and should not override these limits.
- *
- *  @param[in] window The window to query.
- *  @param[in] xpos The x-coordinate of the upper-left corner of the content area.
- *  @param[in] ypos The y-coordinate of the upper-left corner of the content area.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
- *
- *  @remark @wayland There is no way for an application to set the global
- *  position of its windows.  This function will emit @ref
- *  GLFW_FEATURE_UNAVAILABLE.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_pos
- *  @sa @ref glfwGetWindowPos
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
-
-/*! @brief Retrieves the size of the content area of the specified window.
- *
- *  This function retrieves the size, in screen coordinates, of the content area
- *  of the specified window.  If you wish to retrieve the size of the
- *  framebuffer of the window in pixels, see @ref glfwGetFramebufferSize.
- *
- *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
- *  non-`NULL` size arguments will be set to zero.
- *
- *  @param[in] window The window whose size to retrieve.
- *  @param[out] width Where to store the width, in screen coordinates, of the
- *  content area, or `NULL`.
- *  @param[out] height Where to store the height, in screen coordinates, of the
- *  content area, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_size
- *  @sa @ref glfwSetWindowSize
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
-
-/*! @brief Sets the size limits of the specified window.
- *
- *  This function sets the size limits of the content area of the specified
- *  window.  If the window is full screen, the size limits only take effect
- *  once it is made windowed.  If the window is not resizable, this function
- *  does nothing.
- *
- *  The size limits are applied immediately to a windowed mode window and may
- *  cause it to be resized.
- *
- *  The maximum dimensions must be greater than or equal to the minimum
- *  dimensions and all must be greater than or equal to zero.
- *
- *  @param[in] window The window to set limits for.
- *  @param[in] minwidth The minimum width, in screen coordinates, of the content
- *  area, or `GLFW_DONT_CARE`.
- *  @param[in] minheight The minimum height, in screen coordinates, of the
- *  content area, or `GLFW_DONT_CARE`.
- *  @param[in] maxwidth The maximum width, in screen coordinates, of the content
- *  area, or `GLFW_DONT_CARE`.
- *  @param[in] maxheight The maximum height, in screen coordinates, of the
- *  content area, or `GLFW_DONT_CARE`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark If you set size limits and an aspect ratio that conflict, the
- *  results are undefined.
- *
- *  @remark @wayland The size limits will not be applied until the window is
- *  actually resized, either by the user or by the compositor.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_sizelimits
- *  @sa @ref glfwSetWindowAspectRatio
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* window, int minwidth, int minheight, int maxwidth, int maxheight);
-
-/*! @brief Sets the aspect ratio of the specified window.
- *
- *  This function sets the required aspect ratio of the content area of the
- *  specified window.  If the window is full screen, the aspect ratio only takes
- *  effect once it is made windowed.  If the window is not resizable, this
- *  function does nothing.
- *
- *  The aspect ratio is specified as a numerator and a denominator and both
- *  values must be greater than zero.  For example, the common 16:9 aspect ratio
- *  is specified as 16 and 9, respectively.
- *
- *  If the numerator and denominator is set to `GLFW_DONT_CARE` then the aspect
- *  ratio limit is disabled.
- *
- *  The aspect ratio is applied immediately to a windowed mode window and may
- *  cause it to be resized.
- *
- *  @param[in] window The window to set limits for.
- *  @param[in] numer The numerator of the desired aspect ratio, or
- *  `GLFW_DONT_CARE`.
- *  @param[in] denom The denominator of the desired aspect ratio, or
- *  `GLFW_DONT_CARE`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark If you set size limits and an aspect ratio that conflict, the
- *  results are undefined.
- *
- *  @remark @wayland The aspect ratio will not be applied until the window is
- *  actually resized, either by the user or by the compositor.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_sizelimits
- *  @sa @ref glfwSetWindowSizeLimits
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow* window, int numer, int denom);
-
-/*! @brief Sets the size of the content area of the specified window.
- *
- *  This function sets the size, in screen coordinates, of the content area of
- *  the specified window.
- *
- *  For full screen windows, this function updates the resolution of its desired
- *  video mode and switches to the video mode closest to it, without affecting
- *  the window's context.  As the context is unaffected, the bit depths of the
- *  framebuffer remain unchanged.
- *
- *  If you wish to update the refresh rate of the desired video mode in addition
- *  to its resolution, see @ref glfwSetWindowMonitor.
- *
- *  The window manager may put limits on what sizes are allowed.  GLFW cannot
- *  and should not override these limits.
- *
- *  @param[in] window The window to resize.
- *  @param[in] width The desired width, in screen coordinates, of the window
- *  content area.
- *  @param[in] height The desired height, in screen coordinates, of the window
- *  content area.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @wayland A full screen window will not attempt to change the mode,
- *  no matter what the requested size.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_size
- *  @sa @ref glfwGetWindowSize
- *  @sa @ref glfwSetWindowMonitor
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
-
-/*! @brief Retrieves the size of the framebuffer of the specified window.
- *
- *  This function retrieves the size, in pixels, of the framebuffer of the
- *  specified window.  If you wish to retrieve the size of the window in screen
- *  coordinates, see @ref glfwGetWindowSize.
- *
- *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
- *  non-`NULL` size arguments will be set to zero.
- *
- *  @param[in] window The window whose framebuffer to query.
- *  @param[out] width Where to store the width, in pixels, of the framebuffer,
- *  or `NULL`.
- *  @param[out] height Where to store the height, in pixels, of the framebuffer,
- *  or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_fbsize
- *  @sa @ref glfwSetFramebufferSizeCallback
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwGetFramebufferSize(GLFWwindow* window, int* width, int* height);
-
-/*! @brief Retrieves the size of the frame of the window.
- *
- *  This function retrieves the size, in screen coordinates, of each edge of the
- *  frame of the specified window.  This size includes the title bar, if the
- *  window has one.  The size of the frame may vary depending on the
- *  [window-related hints](@ref window_hints_wnd) used to create it.
- *
- *  Because this function retrieves the size of each window frame edge and not
- *  the offset along a particular coordinate axis, the retrieved values will
- *  always be zero or positive.
- *
- *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
- *  non-`NULL` size arguments will be set to zero.
- *
- *  @param[in] window The window whose frame size to query.
- *  @param[out] left Where to store the size, in screen coordinates, of the left
- *  edge of the window frame, or `NULL`.
- *  @param[out] top Where to store the size, in screen coordinates, of the top
- *  edge of the window frame, or `NULL`.
- *  @param[out] right Where to store the size, in screen coordinates, of the
- *  right edge of the window frame, or `NULL`.
- *  @param[out] bottom Where to store the size, in screen coordinates, of the
- *  bottom edge of the window frame, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_size
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwGetWindowFrameSize(GLFWwindow* window, int* left, int* top, int* right, int* bottom);
-
-/*! @brief Retrieves the content scale for the specified window.
- *
- *  This function retrieves the content scale for the specified window.  The
- *  content scale is the ratio between the current DPI and the platform's
- *  default DPI.  This is especially important for text and any UI elements.  If
- *  the pixel dimensions of your UI scaled by this look appropriate on your
- *  machine then it should appear at a reasonable size on other machines
- *  regardless of their DPI and scaling settings.  This relies on the system DPI
- *  and scaling settings being somewhat correct.
- *
- *  On systems where each monitors can have its own content scale, the window
- *  content scale will depend on which monitor the system considers the window
- *  to be on.
- *
- *  @param[in] window The window to query.
- *  @param[out] xscale Where to store the x-axis content scale, or `NULL`.
- *  @param[out] yscale Where to store the y-axis content scale, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_scale
- *  @sa @ref glfwSetWindowContentScaleCallback
- *  @sa @ref glfwGetMonitorContentScale
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwGetWindowContentScale(GLFWwindow* window, float* xscale, float* yscale);
-
-/*! @brief Returns the opacity of the whole window.
- *
- *  This function returns the opacity of the window, including any decorations.
- *
- *  The opacity (or alpha) value is a positive finite number between zero and
- *  one, where zero is fully transparent and one is fully opaque.  If the system
- *  does not support whole window transparency, this function always returns one.
- *
- *  The initial opacity value for newly created windows is one.
- *
- *  @param[in] window The window to query.
- *  @return The opacity value of the specified window.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_transparency
- *  @sa @ref glfwSetWindowOpacity
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI float glfwGetWindowOpacity(GLFWwindow* window);
-
-/*! @brief Sets the opacity of the whole window.
- *
- *  This function sets the opacity of the window, including any decorations.
- *
- *  The opacity (or alpha) value is a positive finite number between zero and
- *  one, where zero is fully transparent and one is fully opaque.
- *
- *  The initial opacity value for newly created windows is one.
- *
- *  A window created with framebuffer transparency may not use whole window
- *  transparency.  The results of doing this are undefined.
- *
- *  @param[in] window The window to set the opacity for.
- *  @param[in] opacity The desired opacity of the specified window.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
- *
- *  @remark @wayland There is no way to set an opacity factor for a window.
- *  This function will emit @ref GLFW_FEATURE_UNAVAILABLE.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_transparency
- *  @sa @ref glfwGetWindowOpacity
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowOpacity(GLFWwindow* window, float opacity);
-
-/*! @brief Iconifies the specified window.
- *
- *  This function iconifies (minimizes) the specified window if it was
- *  previously restored.  If the window is already iconified, this function does
- *  nothing.
- *
- *  If the specified window is a full screen window, the original monitor
- *  resolution is restored until the window is restored.
- *
- *  @param[in] window The window to iconify.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @wayland Once a window is iconified, @ref glfwRestoreWindow won’t
- *  be able to restore it.  This is a design decision of the xdg-shell
- *  protocol.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_iconify
- *  @sa @ref glfwRestoreWindow
- *  @sa @ref glfwMaximizeWindow
- *
- *  @since Added in version 2.1.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwIconifyWindow(GLFWwindow* window);
-
-/*! @brief Restores the specified window.
- *
- *  This function restores the specified window if it was previously iconified
- *  (minimized) or maximized.  If the window is already restored, this function
- *  does nothing.
- *
- *  If the specified window is a full screen window, the resolution chosen for
- *  the window is restored on the selected monitor.
- *
- *  @param[in] window The window to restore.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_iconify
- *  @sa @ref glfwIconifyWindow
- *  @sa @ref glfwMaximizeWindow
- *
- *  @since Added in version 2.1.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwRestoreWindow(GLFWwindow* window);
-
-/*! @brief Maximizes the specified window.
- *
- *  This function maximizes the specified window if it was previously not
- *  maximized.  If the window is already maximized, this function does nothing.
- *
- *  If the specified window is a full screen window, this function does nothing.
- *
- *  @param[in] window The window to maximize.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @par Thread Safety
- *  This function may only be called from the main thread.
- *
- *  @sa @ref window_iconify
- *  @sa @ref glfwIconifyWindow
- *  @sa @ref glfwRestoreWindow
- *
- *  @since Added in GLFW 3.2.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwMaximizeWindow(GLFWwindow* window);
-
-/*! @brief Makes the specified window visible.
- *
- *  This function makes the specified window visible if it was previously
- *  hidden.  If the window is already visible or is in full screen mode, this
- *  function does nothing.
- *
- *  By default, windowed mode windows are focused when shown
- *  Set the [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_hint) window hint
- *  to change this behavior for all newly created windows, or change the
- *  behavior for an existing window with @ref glfwSetWindowAttrib.
- *
- *  @param[in] window The window to make visible.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_hide
- *  @sa @ref glfwHideWindow
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwShowWindow(GLFWwindow* window);
-
-/*! @brief Hides the specified window.
- *
- *  This function hides the specified window if it was previously visible.  If
- *  the window is already hidden or is in full screen mode, this function does
- *  nothing.
- *
- *  @param[in] window The window to hide.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_hide
- *  @sa @ref glfwShowWindow
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwHideWindow(GLFWwindow* window);
-
-/*! @brief Brings the specified window to front and sets input focus.
- *
- *  This function brings the specified window to front and sets input focus.
- *  The window should already be visible and not iconified.
- *
- *  By default, both windowed and full screen mode windows are focused when
- *  initially created.  Set the [GLFW_FOCUSED](@ref GLFW_FOCUSED_hint) to
- *  disable this behavior.
- *
- *  Also by default, windowed mode windows are focused when shown
- *  with @ref glfwShowWindow. Set the
- *  [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_hint) to disable this behavior.
- *
- *  __Do not use this function__ to steal focus from other applications unless
- *  you are certain that is what the user wants.  Focus stealing can be
- *  extremely disruptive.
- *
- *  For a less disruptive way of getting the user's attention, see
- *  [attention requests](@ref window_attention).
- *
- *  @param[in] window The window to give input focus.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
- *
- *  @remark @wayland It is not possible for an application to set the input
- *  focus.  This function will emit @ref GLFW_FEATURE_UNAVAILABLE.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_focus
- *  @sa @ref window_attention
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwFocusWindow(GLFWwindow* window);
-
-/*! @brief Requests user attention to the specified window.
- *
- *  This function requests user attention to the specified window.  On
- *  platforms where this is not supported, attention is requested to the
- *  application as a whole.
- *
- *  Once the user has given attention, usually by focusing the window or
- *  application, the system will end the request automatically.
- *
- *  @param[in] window The window to request attention to.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @macos Attention is requested to the application as a whole, not the
- *  specific window.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_attention
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwRequestWindowAttention(GLFWwindow* window);
-
-/*! @brief Returns the monitor that the window uses for full screen mode.
- *
- *  This function returns the handle of the monitor that the specified window is
- *  in full screen on.
- *
- *  @param[in] window The window to query.
- *  @return The monitor, or `NULL` if the window is in windowed mode or an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_monitor
- *  @sa @ref glfwSetWindowMonitor
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWmonitor* glfwGetWindowMonitor(GLFWwindow* window);
-
-/*! @brief Sets the mode, monitor, video mode and placement of a window.
- *
- *  This function sets the monitor that the window uses for full screen mode or,
- *  if the monitor is `NULL`, makes it windowed mode.
- *
- *  When setting a monitor, this function updates the width, height and refresh
- *  rate of the desired video mode and switches to the video mode closest to it.
- *  The window position is ignored when setting a monitor.
- *
- *  When the monitor is `NULL`, the position, width and height are used to
- *  place the window content area.  The refresh rate is ignored when no monitor
- *  is specified.
- *
- *  If you only wish to update the resolution of a full screen window or the
- *  size of a windowed mode window, see @ref glfwSetWindowSize.
- *
- *  When a window transitions from full screen to windowed mode, this function
- *  restores any previous window settings such as whether it is decorated,
- *  floating, resizable, has size or aspect ratio limits, etc.
- *
- *  @param[in] window The window whose monitor, size or video mode to set.
- *  @param[in] monitor The desired monitor, or `NULL` to set windowed mode.
- *  @param[in] xpos The desired x-coordinate of the upper-left corner of the
- *  content area.
- *  @param[in] ypos The desired y-coordinate of the upper-left corner of the
- *  content area.
- *  @param[in] width The desired with, in screen coordinates, of the content
- *  area or video mode.
- *  @param[in] height The desired height, in screen coordinates, of the content
- *  area or video mode.
- *  @param[in] refreshRate The desired refresh rate, in Hz, of the video mode,
- *  or `GLFW_DONT_CARE`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark The OpenGL or OpenGL ES context will not be destroyed or otherwise
- *  affected by any resizing or mode switching, although you may need to update
- *  your viewport if the framebuffer size has changed.
- *
- *  @remark @wayland The desired window position is ignored, as there is no way
- *  for an application to set this property.
- *
- *  @remark @wayland Setting the window to full screen will not attempt to
- *  change the mode, no matter what the requested size or refresh rate.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_monitor
- *  @sa @ref window_full_screen
- *  @sa @ref glfwGetWindowMonitor
- *  @sa @ref glfwSetWindowSize
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowMonitor(GLFWwindow* window, GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
-
-/*! @brief Returns an attribute of the specified window.
- *
- *  This function returns the value of an attribute of the specified window or
- *  its OpenGL or OpenGL ES context.
- *
- *  @param[in] window The window to query.
- *  @param[in] attrib The [window attribute](@ref window_attribs) whose value to
- *  return.
- *  @return The value of the attribute, or zero if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark Framebuffer related hints are not window attributes.  See @ref
- *  window_attribs_fb for more information.
- *
- *  @remark Zero is a valid value for many window and context related
- *  attributes so you cannot use a return value of zero as an indication of
- *  errors.  However, this function should not fail as long as it is passed
- *  valid arguments and the library has been [initialized](@ref intro_init).
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_attribs
- *  @sa @ref glfwSetWindowAttrib
- *
- *  @since Added in version 3.0.  Replaces `glfwGetWindowParam` and
- *  `glfwGetGLVersion`.
- *
- *  @ingroup window
- */
-GLFWAPI int glfwGetWindowAttrib(GLFWwindow* window, int attrib);
-
-/*! @brief Sets an attribute of the specified window.
- *
- *  This function sets the value of an attribute of the specified window.
- *
- *  The supported attributes are [GLFW_DECORATED](@ref GLFW_DECORATED_attrib),
- *  [GLFW_RESIZABLE](@ref GLFW_RESIZABLE_attrib),
- *  [GLFW_FLOATING](@ref GLFW_FLOATING_attrib),
- *  [GLFW_AUTO_ICONIFY](@ref GLFW_AUTO_ICONIFY_attrib) and
- *  [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_attrib).
- *  [GLFW_MOUSE_PASSTHROUGH](@ref GLFW_MOUSE_PASSTHROUGH_attrib)
- *
- *  Some of these attributes are ignored for full screen windows.  The new
- *  value will take effect if the window is later made windowed.
- *
- *  Some of these attributes are ignored for windowed mode windows.  The new
- *  value will take effect if the window is later made full screen.
- *
- *  @param[in] window The window to set the attribute for.
- *  @param[in] attrib A supported window attribute.
- *  @param[in] value `GLFW_TRUE` or `GLFW_FALSE`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark Calling @ref glfwGetWindowAttrib will always return the latest
- *  value, even if that value is ignored by the current mode of the window.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_attribs
- *  @sa @ref glfwGetWindowAttrib
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowAttrib(GLFWwindow* window, int attrib, int value);
-
-/*! @brief Sets the user pointer of the specified window.
- *
- *  This function sets the user-defined pointer of the specified window.  The
- *  current value is retained until the window is destroyed.  The initial value
- *  is `NULL`.
- *
- *  @param[in] window The window whose pointer to set.
- *  @param[in] pointer The new value.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref window_userptr
- *  @sa @ref glfwGetWindowUserPointer
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSetWindowUserPointer(GLFWwindow* window, void* pointer);
-
-/*! @brief Returns the user pointer of the specified window.
- *
- *  This function returns the current value of the user-defined pointer of the
- *  specified window.  The initial value is `NULL`.
- *
- *  @param[in] window The window whose pointer to return.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref window_userptr
- *  @sa @ref glfwSetWindowUserPointer
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI void* glfwGetWindowUserPointer(GLFWwindow* window);
-
-/*! @brief Sets the position callback for the specified window.
- *
- *  This function sets the position callback of the specified window, which is
- *  called when the window is moved.  The callback is provided with the
- *  position, in screen coordinates, of the upper-left corner of the content
- *  area of the window.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int xpos, int ypos)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowposfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @remark @wayland This callback will never be called, as there is no way for
- *  an application to know its global position.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_pos
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* window, GLFWwindowposfun callback);
-
-/*! @brief Sets the size callback for the specified window.
- *
- *  This function sets the size callback of the specified window, which is
- *  called when the window is resized.  The callback is provided with the size,
- *  in screen coordinates, of the content area of the window.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int width, int height)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowsizefun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_size
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter and return value.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwindowsizefun callback);
-
-/*! @brief Sets the close callback for the specified window.
- *
- *  This function sets the close callback of the specified window, which is
- *  called when the user attempts to close the window, for example by clicking
- *  the close widget in the title bar.
- *
- *  The close flag is set before this callback is called, but you can modify it
- *  at any time with @ref glfwSetWindowShouldClose.
- *
- *  The close callback is not triggered by @ref glfwDestroyWindow.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowclosefun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @remark @macos Selecting Quit from the application menu will trigger the
- *  close callback for all windows.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_close
- *
- *  @since Added in version 2.5.
- *  @glfw3 Added window handle parameter and return value.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* window, GLFWwindowclosefun callback);
-
-/*! @brief Sets the refresh callback for the specified window.
- *
- *  This function sets the refresh callback of the specified window, which is
- *  called when the content area of the window needs to be redrawn, for example
- *  if the window has been exposed after having been covered by another window.
- *
- *  On compositing window systems such as Aero, Compiz, Aqua or Wayland, where
- *  the window contents are saved off-screen, this callback may be called only
- *  very infrequently or never at all.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window);
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowrefreshfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_refresh
- *
- *  @since Added in version 2.5.
- *  @glfw3 Added window handle parameter and return value.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* window, GLFWwindowrefreshfun callback);
-
-/*! @brief Sets the focus callback for the specified window.
- *
- *  This function sets the focus callback of the specified window, which is
- *  called when the window gains or loses input focus.
- *
- *  After the focus callback is called for a window that lost input focus,
- *  synthetic key and mouse button release events will be generated for all such
- *  that had been pressed.  For more information, see @ref glfwSetKeyCallback
- *  and @ref glfwSetMouseButtonCallback.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int focused)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowfocusfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_focus
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwindowfocusfun callback);
-
-/*! @brief Sets the iconify callback for the specified window.
- *
- *  This function sets the iconification callback of the specified window, which
- *  is called when the window is iconified or restored.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int iconified)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowiconifyfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_iconify
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* window, GLFWwindowiconifyfun callback);
-
-/*! @brief Sets the maximize callback for the specified window.
- *
- *  This function sets the maximization callback of the specified window, which
- *  is called when the window is maximized or restored.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int maximized)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowmaximizefun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_maximize
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow* window, GLFWwindowmaximizefun callback);
-
-/*! @brief Sets the framebuffer resize callback for the specified window.
- *
- *  This function sets the framebuffer resize callback of the specified window,
- *  which is called when the framebuffer of the specified window is resized.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int width, int height)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWframebuffersizefun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_fbsize
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* window, GLFWframebuffersizefun callback);
-
-/*! @brief Sets the window content scale callback for the specified window.
- *
- *  This function sets the window content scale callback of the specified window,
- *  which is called when the content scale of the specified window changes.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, float xscale, float yscale)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWwindowcontentscalefun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref window_scale
- *  @sa @ref glfwGetWindowContentScale
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup window
- */
-GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(GLFWwindow* window, GLFWwindowcontentscalefun callback);
-
-/*! @brief Processes all pending events.
- *
- *  This function processes only those events that are already in the event
- *  queue and then returns immediately.  Processing events will cause the window
- *  and input callbacks associated with those events to be called.
- *
- *  On some platforms, a window move, resize or menu operation will cause event
- *  processing to block.  This is due to how event processing is designed on
- *  those platforms.  You can use the
- *  [window refresh callback](@ref window_refresh) to redraw the contents of
- *  your window when necessary during such operations.
- *
- *  Do not assume that callbacks you set will _only_ be called in response to
- *  event processing functions like this one.  While it is necessary to poll for
- *  events, window systems that require GLFW to register callbacks of its own
- *  can pass events to GLFW in response to many window system function calls.
- *  GLFW will pass those events on to the application callbacks before
- *  returning.
- *
- *  Event processing is not required for joystick input to work.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @reentrancy This function must not be called from a callback.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref events
- *  @sa @ref glfwWaitEvents
- *  @sa @ref glfwWaitEventsTimeout
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwPollEvents(void);
-
-/*! @brief Waits until events are queued and processes them.
- *
- *  This function puts the calling thread to sleep until at least one event is
- *  available in the event queue.  Once one or more events are available,
- *  it behaves exactly like @ref glfwPollEvents, i.e. the events in the queue
- *  are processed and the function then returns immediately.  Processing events
- *  will cause the window and input callbacks associated with those events to be
- *  called.
- *
- *  Since not all events are associated with callbacks, this function may return
- *  without a callback having been called even if you are monitoring all
- *  callbacks.
- *
- *  On some platforms, a window move, resize or menu operation will cause event
- *  processing to block.  This is due to how event processing is designed on
- *  those platforms.  You can use the
- *  [window refresh callback](@ref window_refresh) to redraw the contents of
- *  your window when necessary during such operations.
- *
- *  Do not assume that callbacks you set will _only_ be called in response to
- *  event processing functions like this one.  While it is necessary to poll for
- *  events, window systems that require GLFW to register callbacks of its own
- *  can pass events to GLFW in response to many window system function calls.
- *  GLFW will pass those events on to the application callbacks before
- *  returning.
- *
- *  Event processing is not required for joystick input to work.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @reentrancy This function must not be called from a callback.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref events
- *  @sa @ref glfwPollEvents
- *  @sa @ref glfwWaitEventsTimeout
- *
- *  @since Added in version 2.5.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwWaitEvents(void);
-
-/*! @brief Waits with timeout until events are queued and processes them.
- *
- *  This function puts the calling thread to sleep until at least one event is
- *  available in the event queue, or until the specified timeout is reached.  If
- *  one or more events are available, it behaves exactly like @ref
- *  glfwPollEvents, i.e. the events in the queue are processed and the function
- *  then returns immediately.  Processing events will cause the window and input
- *  callbacks associated with those events to be called.
- *
- *  The timeout value must be a positive finite number.
- *
- *  Since not all events are associated with callbacks, this function may return
- *  without a callback having been called even if you are monitoring all
- *  callbacks.
- *
- *  On some platforms, a window move, resize or menu operation will cause event
- *  processing to block.  This is due to how event processing is designed on
- *  those platforms.  You can use the
- *  [window refresh callback](@ref window_refresh) to redraw the contents of
- *  your window when necessary during such operations.
- *
- *  Do not assume that callbacks you set will _only_ be called in response to
- *  event processing functions like this one.  While it is necessary to poll for
- *  events, window systems that require GLFW to register callbacks of its own
- *  can pass events to GLFW in response to many window system function calls.
- *  GLFW will pass those events on to the application callbacks before
- *  returning.
- *
- *  Event processing is not required for joystick input to work.
- *
- *  @param[in] timeout The maximum amount of time, in seconds, to wait.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
- *
- *  @reentrancy This function must not be called from a callback.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref events
- *  @sa @ref glfwPollEvents
- *  @sa @ref glfwWaitEvents
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwWaitEventsTimeout(double timeout);
-
-/*! @brief Posts an empty event to the event queue.
- *
- *  This function posts an empty event from the current thread to the event
- *  queue, causing @ref glfwWaitEvents or @ref glfwWaitEventsTimeout to return.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref events
- *  @sa @ref glfwWaitEvents
- *  @sa @ref glfwWaitEventsTimeout
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwPostEmptyEvent(void);
-
-/*! @brief Returns the value of an input option for the specified window.
- *
- *  This function returns the value of an input option for the specified window.
- *  The mode must be one of @ref GLFW_CURSOR, @ref GLFW_STICKY_KEYS,
- *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS or
- *  @ref GLFW_RAW_MOUSE_MOTION.
- *
- *  @param[in] window The window to query.
- *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
- *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
- *  `GLFW_RAW_MOUSE_MOTION`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref glfwSetInputMode
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
-
-/*! @brief Sets an input option for the specified window.
- *
- *  This function sets an input mode option for the specified window.  The mode
- *  must be one of @ref GLFW_CURSOR, @ref GLFW_STICKY_KEYS,
- *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS or
- *  @ref GLFW_RAW_MOUSE_MOTION.
- *
- *  If the mode is `GLFW_CURSOR`, the value must be one of the following cursor
- *  modes:
- *  - `GLFW_CURSOR_NORMAL` makes the cursor visible and behaving normally.
- *  - `GLFW_CURSOR_HIDDEN` makes the cursor invisible when it is over the
- *    content area of the window but does not restrict the cursor from leaving.
- *  - `GLFW_CURSOR_DISABLED` hides and grabs the cursor, providing virtual
- *    and unlimited cursor movement.  This is useful for implementing for
- *    example 3D camera controls.
- *
- *  If the mode is `GLFW_STICKY_KEYS`, the value must be either `GLFW_TRUE` to
- *  enable sticky keys, or `GLFW_FALSE` to disable it.  If sticky keys are
- *  enabled, a key press will ensure that @ref glfwGetKey returns `GLFW_PRESS`
- *  the next time it is called even if the key had been released before the
- *  call.  This is useful when you are only interested in whether keys have been
- *  pressed but not when or in which order.
- *
- *  If the mode is `GLFW_STICKY_MOUSE_BUTTONS`, the value must be either
- *  `GLFW_TRUE` to enable sticky mouse buttons, or `GLFW_FALSE` to disable it.
- *  If sticky mouse buttons are enabled, a mouse button press will ensure that
- *  @ref glfwGetMouseButton returns `GLFW_PRESS` the next time it is called even
- *  if the mouse button had been released before the call.  This is useful when
- *  you are only interested in whether mouse buttons have been pressed but not
- *  when or in which order.
- *
- *  If the mode is `GLFW_LOCK_KEY_MODS`, the value must be either `GLFW_TRUE` to
- *  enable lock key modifier bits, or `GLFW_FALSE` to disable them.  If enabled,
- *  callbacks that receive modifier bits will also have the @ref
- *  GLFW_MOD_CAPS_LOCK bit set when the event was generated with Caps Lock on,
- *  and the @ref GLFW_MOD_NUM_LOCK bit when Num Lock was on.
- *
- *  If the mode is `GLFW_RAW_MOUSE_MOTION`, the value must be either `GLFW_TRUE`
- *  to enable raw (unscaled and unaccelerated) mouse motion when the cursor is
- *  disabled, or `GLFW_FALSE` to disable it.  If raw motion is not supported,
- *  attempting to set this will emit @ref GLFW_FEATURE_UNAVAILABLE.  Call @ref
- *  glfwRawMouseMotionSupported to check for support.
- *
- *  @param[in] window The window whose input mode to set.
- *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
- *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
- *  `GLFW_RAW_MOUSE_MOTION`.
- *  @param[in] value The new value of the specified input mode.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM, @ref GLFW_PLATFORM_ERROR and @ref
- *  GLFW_FEATURE_UNAVAILABLE (see above).
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref glfwGetInputMode
- *
- *  @since Added in version 3.0.  Replaces `glfwEnable` and `glfwDisable`.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwSetInputMode(GLFWwindow* window, int mode, int value);
-
-/*! @brief Returns whether raw mouse motion is supported.
- *
- *  This function returns whether raw mouse motion is supported on the current
- *  system.  This status does not change after GLFW has been initialized so you
- *  only need to check this once.  If you attempt to enable raw motion on
- *  a system that does not support it, @ref GLFW_PLATFORM_ERROR will be emitted.
- *
- *  Raw mouse motion is closer to the actual motion of the mouse across
- *  a surface.  It is not affected by the scaling and acceleration applied to
- *  the motion of the desktop cursor.  That processing is suitable for a cursor
- *  while raw motion is better for controlling for example a 3D camera.  Because
- *  of this, raw mouse motion is only provided when the cursor is disabled.
- *
- *  @return `GLFW_TRUE` if raw mouse motion is supported on the current machine,
- *  or `GLFW_FALSE` otherwise.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref raw_mouse_motion
- *  @sa @ref glfwSetInputMode
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwRawMouseMotionSupported(void);
-
-/*! @brief Returns the layout-specific name of the specified printable key.
- *
- *  This function returns the name of the specified printable key, encoded as
- *  UTF-8.  This is typically the character that key would produce without any
- *  modifier keys, intended for displaying key bindings to the user.  For dead
- *  keys, it is typically the diacritic it would add to a character.
- *
- *  __Do not use this function__ for [text input](@ref input_char).  You will
- *  break text input for many languages even if it happens to work for yours.
- *
- *  If the key is `GLFW_KEY_UNKNOWN`, the scancode is used to identify the key,
- *  otherwise the scancode is ignored.  If you specify a non-printable key, or
- *  `GLFW_KEY_UNKNOWN` and a scancode that maps to a non-printable key, this
- *  function returns `NULL` but does not emit an error.
- *
- *  This behavior allows you to always pass in the arguments in the
- *  [key callback](@ref input_key) without modification.
- *
- *  The printable keys are:
- *  - `GLFW_KEY_APOSTROPHE`
- *  - `GLFW_KEY_COMMA`
- *  - `GLFW_KEY_MINUS`
- *  - `GLFW_KEY_PERIOD`
- *  - `GLFW_KEY_SLASH`
- *  - `GLFW_KEY_SEMICOLON`
- *  - `GLFW_KEY_EQUAL`
- *  - `GLFW_KEY_LEFT_BRACKET`
- *  - `GLFW_KEY_RIGHT_BRACKET`
- *  - `GLFW_KEY_BACKSLASH`
- *  - `GLFW_KEY_WORLD_1`
- *  - `GLFW_KEY_WORLD_2`
- *  - `GLFW_KEY_0` to `GLFW_KEY_9`
- *  - `GLFW_KEY_A` to `GLFW_KEY_Z`
- *  - `GLFW_KEY_KP_0` to `GLFW_KEY_KP_9`
- *  - `GLFW_KEY_KP_DECIMAL`
- *  - `GLFW_KEY_KP_DIVIDE`
- *  - `GLFW_KEY_KP_MULTIPLY`
- *  - `GLFW_KEY_KP_SUBTRACT`
- *  - `GLFW_KEY_KP_ADD`
- *  - `GLFW_KEY_KP_EQUAL`
- *
- *  Names for printable keys depend on keyboard layout, while names for
- *  non-printable keys are the same across layouts but depend on the application
- *  language and should be localized along with other user interface text.
- *
- *  @param[in] key The key to query, or `GLFW_KEY_UNKNOWN`.
- *  @param[in] scancode The scancode of the key to query.
- *  @return The UTF-8 encoded, layout-specific name of the key, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark The contents of the returned string may change when a keyboard
- *  layout change event is received.
- *
- *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref input_key_name
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup input
- */
-GLFWAPI const char* glfwGetKeyName(int key, int scancode);
-
-/*! @brief Returns the platform-specific scancode of the specified key.
- *
- *  This function returns the platform-specific scancode of the specified key.
- *
- *  If the key is `GLFW_KEY_UNKNOWN` or does not exist on the keyboard this
- *  method will return `-1`.
- *
- *  @param[in] key Any [named key](@ref keys).
- *  @return The platform-specific scancode for the key, or `-1` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref input_key
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwGetKeyScancode(int key);
-
-/*! @brief Returns the last reported state of a keyboard key for the specified
- *  window.
- *
- *  This function returns the last state reported for the specified key to the
- *  specified window.  The returned state is one of `GLFW_PRESS` or
- *  `GLFW_RELEASE`.  The higher-level action `GLFW_REPEAT` is only reported to
- *  the key callback.
- *
- *  If the @ref GLFW_STICKY_KEYS input mode is enabled, this function returns
- *  `GLFW_PRESS` the first time you call it for a key that was pressed, even if
- *  that key has already been released.
- *
- *  The key functions deal with physical keys, with [key tokens](@ref keys)
- *  named after their use on the standard US keyboard layout.  If you want to
- *  input text, use the Unicode character callback instead.
- *
- *  The [modifier key bit masks](@ref mods) are not key tokens and cannot be
- *  used with this function.
- *
- *  __Do not use this function__ to implement [text input](@ref input_char).
- *
- *  @param[in] window The desired window.
- *  @param[in] key The desired [keyboard key](@ref keys).  `GLFW_KEY_UNKNOWN` is
- *  not a valid key for this function.
- *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref input_key
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwGetKey(GLFWwindow* window, int key);
-
-/*! @brief Returns the last reported state of a mouse button for the specified
- *  window.
- *
- *  This function returns the last state reported for the specified mouse button
- *  to the specified window.  The returned state is one of `GLFW_PRESS` or
- *  `GLFW_RELEASE`.
- *
- *  If the @ref GLFW_STICKY_MOUSE_BUTTONS input mode is enabled, this function
- *  returns `GLFW_PRESS` the first time you call it for a mouse button that was
- *  pressed, even if that mouse button has already been released.
- *
- *  @param[in] window The desired window.
- *  @param[in] button The desired [mouse button](@ref buttons).
- *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref input_mouse_button
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwGetMouseButton(GLFWwindow* window, int button);
-
-/*! @brief Retrieves the position of the cursor relative to the content area of
- *  the window.
- *
- *  This function returns the position of the cursor, in screen coordinates,
- *  relative to the upper-left corner of the content area of the specified
- *  window.
- *
- *  If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
- *  position is unbounded and limited only by the minimum and maximum values of
- *  a `double`.
- *
- *  The coordinate can be converted to their integer equivalents with the
- *  `floor` function.  Casting directly to an integer type works for positive
- *  coordinates, but fails for negative ones.
- *
- *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
- *  non-`NULL` position arguments will be set to zero.
- *
- *  @param[in] window The desired window.
- *  @param[out] xpos Where to store the cursor x-coordinate, relative to the
- *  left edge of the content area, or `NULL`.
- *  @param[out] ypos Where to store the cursor y-coordinate, relative to the to
- *  top edge of the content area, or `NULL`.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_pos
- *  @sa @ref glfwSetCursorPos
- *
- *  @since Added in version 3.0.  Replaces `glfwGetMousePos`.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
-
-/*! @brief Sets the position of the cursor, relative to the content area of the
- *  window.
- *
- *  This function sets the position, in screen coordinates, of the cursor
- *  relative to the upper-left corner of the content area of the specified
- *  window.  The window must have input focus.  If the window does not have
- *  input focus when this function is called, it fails silently.
- *
- *  __Do not use this function__ to implement things like camera controls.  GLFW
- *  already provides the `GLFW_CURSOR_DISABLED` cursor mode that hides the
- *  cursor, transparently re-centers it and provides unconstrained cursor
- *  motion.  See @ref glfwSetInputMode for more information.
- *
- *  If the cursor mode is `GLFW_CURSOR_DISABLED` then the cursor position is
- *  unconstrained and limited only by the minimum and maximum values of
- *  a `double`.
- *
- *  @param[in] window The desired window.
- *  @param[in] xpos The desired x-coordinate, relative to the left edge of the
- *  content area.
- *  @param[in] ypos The desired y-coordinate, relative to the top edge of the
- *  content area.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @remark @wayland This function will only work when the cursor mode is
- *  `GLFW_CURSOR_DISABLED`, otherwise it will do nothing.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_pos
- *  @sa @ref glfwGetCursorPos
- *
- *  @since Added in version 3.0.  Replaces `glfwSetMousePos`.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
-
-/*! @brief Creates a custom cursor.
- *
- *  Creates a new custom cursor image that can be set for a window with @ref
- *  glfwSetCursor.  The cursor can be destroyed with @ref glfwDestroyCursor.
- *  Any remaining cursors are destroyed by @ref glfwTerminate.
- *
- *  The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
- *  bits per channel with the red channel first.  They are arranged canonically
- *  as packed sequential rows, starting from the top-left corner.
- *
- *  The cursor hotspot is specified in pixels, relative to the upper-left corner
- *  of the cursor image.  Like all other coordinate systems in GLFW, the X-axis
- *  points to the right and the Y-axis points down.
- *
- *  @param[in] image The desired cursor image.
- *  @param[in] xhot The desired x-coordinate, in pixels, of the cursor hotspot.
- *  @param[in] yhot The desired y-coordinate, in pixels, of the cursor hotspot.
- *  @return The handle of the created cursor, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The specified image data is copied before this function
- *  returns.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_object
- *  @sa @ref glfwDestroyCursor
- *  @sa @ref glfwCreateStandardCursor
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWcursor* glfwCreateCursor(const GLFWimage* image, int xhot, int yhot);
-
-/*! @brief Creates a cursor with a standard shape.
- *
- *  Returns a cursor with a standard shape, that can be set for a window with
- *  @ref glfwSetCursor.  The images for these cursors come from the system
- *  cursor theme and their exact appearance will vary between platforms.
- *
- *  Most of these shapes are guaranteed to exist on every supported platform but
- *  a few may not be present.  See the table below for details.
- *
- *  Cursor shape                   | Windows | macOS | X11    | Wayland
- *  ------------------------------ | ------- | ----- | ------ | -------
- *  @ref GLFW_ARROW_CURSOR         | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_IBEAM_CURSOR         | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_CROSSHAIR_CURSOR     | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_POINTING_HAND_CURSOR | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_RESIZE_EW_CURSOR     | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_RESIZE_NS_CURSOR     | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_RESIZE_NWSE_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
- *  @ref GLFW_RESIZE_NESW_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
- *  @ref GLFW_RESIZE_ALL_CURSOR    | Yes     | Yes   | Yes    | Yes
- *  @ref GLFW_NOT_ALLOWED_CURSOR   | Yes     | Yes   | Maybe<sup>2</sup> | Maybe<sup>2</sup>
- *
- *  1) This uses a private system API and may fail in the future.
- *
- *  2) This uses a newer standard that not all cursor themes support.
- *
- *  If the requested shape is not available, this function emits a @ref
- *  GLFW_CURSOR_UNAVAILABLE error and returns `NULL`.
- *
- *  @param[in] shape One of the [standard shapes](@ref shapes).
- *  @return A new cursor ready to use or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM, @ref GLFW_CURSOR_UNAVAILABLE and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_standard
- *  @sa @ref glfwCreateCursor
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWcursor* glfwCreateStandardCursor(int shape);
-
-/*! @brief Destroys a cursor.
- *
- *  This function destroys a cursor previously created with @ref
- *  glfwCreateCursor.  Any remaining cursors will be destroyed by @ref
- *  glfwTerminate.
- *
- *  If the specified cursor is current for any window, that window will be
- *  reverted to the default cursor.  This does not affect the cursor mode.
- *
- *  @param[in] cursor The cursor object to destroy.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @reentrancy This function must not be called from a callback.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_object
- *  @sa @ref glfwCreateCursor
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwDestroyCursor(GLFWcursor* cursor);
-
-/*! @brief Sets the cursor for the window.
- *
- *  This function sets the cursor image to be used when the cursor is over the
- *  content area of the specified window.  The set cursor will only be visible
- *  when the [cursor mode](@ref cursor_mode) of the window is
- *  `GLFW_CURSOR_NORMAL`.
- *
- *  On some platforms, the set cursor may not be visible unless the window also
- *  has input focus.
- *
- *  @param[in] window The window to set the cursor for.
- *  @param[in] cursor The cursor to set, or `NULL` to switch back to the default
- *  arrow cursor.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_object
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwSetCursor(GLFWwindow* window, GLFWcursor* cursor);
-
-/*! @brief Sets the key callback.
- *
- *  This function sets the key callback of the specified window, which is called
- *  when a key is pressed, repeated or released.
- *
- *  The key functions deal with physical keys, with layout independent
- *  [key tokens](@ref keys) named after their values in the standard US keyboard
- *  layout.  If you want to input text, use the
- *  [character callback](@ref glfwSetCharCallback) instead.
- *
- *  When a window loses input focus, it will generate synthetic key release
- *  events for all pressed keys.  You can tell these events from user-generated
- *  events by the fact that the synthetic ones are generated after the focus
- *  loss event has been processed, i.e. after the
- *  [window focus callback](@ref glfwSetWindowFocusCallback) has been called.
- *
- *  The scancode of a key is specific to that platform or sometimes even to that
- *  machine.  Scancodes are intended to allow users to bind keys that don't have
- *  a GLFW key token.  Such keys have `key` set to `GLFW_KEY_UNKNOWN`, their
- *  state is not saved and so it cannot be queried with @ref glfwGetKey.
- *
- *  Sometimes GLFW needs to generate synthetic key events, in which case the
- *  scancode may be zero.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new key callback, or `NULL` to remove the currently
- *  set callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWkeyfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref input_key
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter and return value.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* window, GLFWkeyfun callback);
-
-/*! @brief Sets the Unicode character callback.
- *
- *  This function sets the character callback of the specified window, which is
- *  called when a Unicode character is input.
- *
- *  The character callback is intended for Unicode text input.  As it deals with
- *  characters, it is keyboard layout dependent, whereas the
- *  [key callback](@ref glfwSetKeyCallback) is not.  Characters do not map 1:1
- *  to physical keys, as a key may produce zero, one or more characters.  If you
- *  want to know whether a specific physical key was pressed or released, see
- *  the key callback instead.
- *
- *  The character callback behaves as system text input normally does and will
- *  not be called if modifier keys are held down that would prevent normal text
- *  input on that platform, for example a Super (Command) key on macOS or Alt key
- *  on Windows.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, unsigned int codepoint)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWcharfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref input_char
- *
- *  @since Added in version 2.4.
- *  @glfw3 Added window handle parameter and return value.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun callback);
-
-/*! @brief Sets the Unicode character with modifiers callback.
- *
- *  This function sets the character with modifiers callback of the specified
- *  window, which is called when a Unicode character is input regardless of what
- *  modifier keys are used.
- *
- *  The character with modifiers callback is intended for implementing custom
- *  Unicode character input.  For regular Unicode text input, see the
- *  [character callback](@ref glfwSetCharCallback).  Like the character
- *  callback, the character with modifiers callback deals with characters and is
- *  keyboard layout dependent.  Characters do not map 1:1 to physical keys, as
- *  a key may produce zero, one or more characters.  If you want to know whether
- *  a specific physical key was pressed or released, see the
- *  [key callback](@ref glfwSetKeyCallback) instead.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or an
- *  [error](@ref error_handling) occurred.
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, unsigned int codepoint, int mods)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWcharmodsfun).
- *
- *  @deprecated Scheduled for removal in version 4.0.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref input_char
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow* window, GLFWcharmodsfun callback);
-
-/*! @brief Sets the mouse button callback.
- *
- *  This function sets the mouse button callback of the specified window, which
- *  is called when a mouse button is pressed or released.
- *
- *  When a window loses input focus, it will generate synthetic mouse button
- *  release events for all pressed mouse buttons.  You can tell these events
- *  from user-generated events by the fact that the synthetic ones are generated
- *  after the focus loss event has been processed, i.e. after the
- *  [window focus callback](@ref glfwSetWindowFocusCallback) has been called.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int button, int action, int mods)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWmousebuttonfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref input_mouse_button
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter and return value.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* window, GLFWmousebuttonfun callback);
-
-/*! @brief Sets the cursor position callback.
- *
- *  This function sets the cursor position callback of the specified window,
- *  which is called when the cursor is moved.  The callback is provided with the
- *  position, in screen coordinates, relative to the upper-left corner of the
- *  content area of the window.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, double xpos, double ypos);
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWcursorposfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_pos
- *
- *  @since Added in version 3.0.  Replaces `glfwSetMousePosCallback`.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow* window, GLFWcursorposfun callback);
-
-/*! @brief Sets the cursor enter/leave callback.
- *
- *  This function sets the cursor boundary crossing callback of the specified
- *  window, which is called when the cursor enters or leaves the content area of
- *  the window.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int entered)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWcursorenterfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref cursor_enter
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow* window, GLFWcursorenterfun callback);
-
-/*! @brief Sets the scroll callback.
- *
- *  This function sets the scroll callback of the specified window, which is
- *  called when a scrolling device is used, such as a mouse wheel or scrolling
- *  area of a touchpad.
- *
- *  The scroll callback receives all scrolling input, like that from a mouse
- *  wheel or a touchpad scrolling area.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new scroll callback, or `NULL` to remove the
- *  currently set callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, double xoffset, double yoffset)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWscrollfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref scrolling
- *
- *  @since Added in version 3.0.  Replaces `glfwSetMouseWheelCallback`.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun callback);
-
-/*! @brief Sets the path drop callback.
- *
- *  This function sets the path drop callback of the specified window, which is
- *  called when one or more dragged paths are dropped on the window.
- *
- *  Because the path array and its strings may have been generated specifically
- *  for that event, they are not guaranteed to be valid after the callback has
- *  returned.  If you wish to use them after the callback returns, you need to
- *  make a deep copy.
- *
- *  @param[in] window The window whose callback to set.
- *  @param[in] callback The new file drop callback, or `NULL` to remove the
- *  currently set callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(GLFWwindow* window, int path_count, const char* paths[])
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWdropfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @remark @wayland File drop is currently unimplemented.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref path_drop
- *
- *  @since Added in version 3.1.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow* window, GLFWdropfun callback);
-
-/*! @brief Returns whether the specified joystick is present.
- *
- *  This function returns whether the specified joystick is present.
- *
- *  There is no need to call this function before other functions that accept
- *  a joystick ID, as they all check for presence before performing any other
- *  work.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @return `GLFW_TRUE` if the joystick is present, or `GLFW_FALSE` otherwise.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref joystick
- *
- *  @since Added in version 3.0.  Replaces `glfwGetJoystickParam`.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwJoystickPresent(int jid);
-
-/*! @brief Returns the values of all axes of the specified joystick.
- *
- *  This function returns the values of all axes of the specified joystick.
- *  Each element in the array is a value between -1.0 and 1.0.
- *
- *  If the specified joystick is not present this function will return `NULL`
- *  but will not generate an error.  This can be used instead of first calling
- *  @ref glfwJoystickPresent.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @param[out] count Where to store the number of axis values in the returned
- *  array.  This is set to zero if the joystick is not present or an error
- *  occurred.
- *  @return An array of axis values, or `NULL` if the joystick is not present or
- *  an [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified joystick is
- *  disconnected or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref joystick_axis
- *
- *  @since Added in version 3.0.  Replaces `glfwGetJoystickPos`.
- *
- *  @ingroup input
- */
-GLFWAPI const float* glfwGetJoystickAxes(int jid, int* count);
-
-/*! @brief Returns the state of all buttons of the specified joystick.
- *
- *  This function returns the state of all buttons of the specified joystick.
- *  Each element in the array is either `GLFW_PRESS` or `GLFW_RELEASE`.
- *
- *  For backward compatibility with earlier versions that did not have @ref
- *  glfwGetJoystickHats, the button array also includes all hats, each
- *  represented as four buttons.  The hats are in the same order as returned by
- *  __glfwGetJoystickHats__ and are in the order _up_, _right_, _down_ and
- *  _left_.  To disable these extra buttons, set the @ref
- *  GLFW_JOYSTICK_HAT_BUTTONS init hint before initialization.
- *
- *  If the specified joystick is not present this function will return `NULL`
- *  but will not generate an error.  This can be used instead of first calling
- *  @ref glfwJoystickPresent.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @param[out] count Where to store the number of button states in the returned
- *  array.  This is set to zero if the joystick is not present or an error
- *  occurred.
- *  @return An array of button states, or `NULL` if the joystick is not present
- *  or an [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified joystick is
- *  disconnected or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref joystick_button
- *
- *  @since Added in version 2.2.
- *  @glfw3 Changed to return a dynamic array.
- *
- *  @ingroup input
- */
-GLFWAPI const unsigned char* glfwGetJoystickButtons(int jid, int* count);
-
-/*! @brief Returns the state of all hats of the specified joystick.
- *
- *  This function returns the state of all hats of the specified joystick.
- *  Each element in the array is one of the following values:
- *
- *  Name                  | Value
- *  ----                  | -----
- *  `GLFW_HAT_CENTERED`   | 0
- *  `GLFW_HAT_UP`         | 1
- *  `GLFW_HAT_RIGHT`      | 2
- *  `GLFW_HAT_DOWN`       | 4
- *  `GLFW_HAT_LEFT`       | 8
- *  `GLFW_HAT_RIGHT_UP`   | `GLFW_HAT_RIGHT` \| `GLFW_HAT_UP`
- *  `GLFW_HAT_RIGHT_DOWN` | `GLFW_HAT_RIGHT` \| `GLFW_HAT_DOWN`
- *  `GLFW_HAT_LEFT_UP`    | `GLFW_HAT_LEFT` \| `GLFW_HAT_UP`
- *  `GLFW_HAT_LEFT_DOWN`  | `GLFW_HAT_LEFT` \| `GLFW_HAT_DOWN`
- *
- *  The diagonal directions are bitwise combinations of the primary (up, right,
- *  down and left) directions and you can test for these individually by ANDing
- *  it with the corresponding direction.
- *
- *  @code
- *  if (hats[2] & GLFW_HAT_RIGHT)
- *  {
- *      // State of hat 2 could be right-up, right or right-down
- *  }
- *  @endcode
- *
- *  If the specified joystick is not present this function will return `NULL`
- *  but will not generate an error.  This can be used instead of first calling
- *  @ref glfwJoystickPresent.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @param[out] count Where to store the number of hat states in the returned
- *  array.  This is set to zero if the joystick is not present or an error
- *  occurred.
- *  @return An array of hat states, or `NULL` if the joystick is not present
- *  or an [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified joystick is
- *  disconnected, this function is called again for that joystick or the library
- *  is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref joystick_hat
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI const unsigned char* glfwGetJoystickHats(int jid, int* count);
-
-/*! @brief Returns the name of the specified joystick.
- *
- *  This function returns the name, encoded as UTF-8, of the specified joystick.
- *  The returned string is allocated and freed by GLFW.  You should not free it
- *  yourself.
- *
- *  If the specified joystick is not present this function will return `NULL`
- *  but will not generate an error.  This can be used instead of first calling
- *  @ref glfwJoystickPresent.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @return The UTF-8 encoded name of the joystick, or `NULL` if the joystick
- *  is not present or an [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified joystick is
- *  disconnected or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref joystick_name
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup input
- */
-GLFWAPI const char* glfwGetJoystickName(int jid);
-
-/*! @brief Returns the SDL compatible GUID of the specified joystick.
- *
- *  This function returns the SDL compatible GUID, as a UTF-8 encoded
- *  hexadecimal string, of the specified joystick.  The returned string is
- *  allocated and freed by GLFW.  You should not free it yourself.
- *
- *  The GUID is what connects a joystick to a gamepad mapping.  A connected
- *  joystick will always have a GUID even if there is no gamepad mapping
- *  assigned to it.
- *
- *  If the specified joystick is not present this function will return `NULL`
- *  but will not generate an error.  This can be used instead of first calling
- *  @ref glfwJoystickPresent.
- *
- *  The GUID uses the format introduced in SDL 2.0.5.  This GUID tries to
- *  uniquely identify the make and model of a joystick but does not identify
- *  a specific unit, e.g. all wired Xbox 360 controllers will have the same
- *  GUID on that platform.  The GUID for a unit may vary between platforms
- *  depending on what hardware information the platform specific APIs provide.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @return The UTF-8 encoded GUID of the joystick, or `NULL` if the joystick
- *  is not present or an [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified joystick is
- *  disconnected or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref gamepad
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI const char* glfwGetJoystickGUID(int jid);
-
-/*! @brief Sets the user pointer of the specified joystick.
- *
- *  This function sets the user-defined pointer of the specified joystick.  The
- *  current value is retained until the joystick is disconnected.  The initial
- *  value is `NULL`.
- *
- *  This function may be called from the joystick callback, even for a joystick
- *  that is being disconnected.
- *
- *  @param[in] jid The joystick whose pointer to set.
- *  @param[in] pointer The new value.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref joystick_userptr
- *  @sa @ref glfwGetJoystickUserPointer
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwSetJoystickUserPointer(int jid, void* pointer);
-
-/*! @brief Returns the user pointer of the specified joystick.
- *
- *  This function returns the current value of the user-defined pointer of the
- *  specified joystick.  The initial value is `NULL`.
- *
- *  This function may be called from the joystick callback, even for a joystick
- *  that is being disconnected.
- *
- *  @param[in] jid The joystick whose pointer to return.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Access is not
- *  synchronized.
- *
- *  @sa @ref joystick_userptr
- *  @sa @ref glfwSetJoystickUserPointer
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI void* glfwGetJoystickUserPointer(int jid);
-
-/*! @brief Returns whether the specified joystick has a gamepad mapping.
- *
- *  This function returns whether the specified joystick is both present and has
- *  a gamepad mapping.
- *
- *  If the specified joystick is present but does not have a gamepad mapping
- *  this function will return `GLFW_FALSE` but will not generate an error.  Call
- *  @ref glfwJoystickPresent to check if a joystick is present regardless of
- *  whether it has a mapping.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @return `GLFW_TRUE` if a joystick is both present and has a gamepad mapping,
- *  or `GLFW_FALSE` otherwise.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref gamepad
- *  @sa @ref glfwGetGamepadState
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwJoystickIsGamepad(int jid);
-
-/*! @brief Sets the joystick configuration callback.
- *
- *  This function sets the joystick configuration callback, or removes the
- *  currently set callback.  This is called when a joystick is connected to or
- *  disconnected from the system.
- *
- *  For joystick connection and disconnection events to be delivered on all
- *  platforms, you need to call one of the [event processing](@ref events)
- *  functions.  Joystick disconnection may also be detected and the callback
- *  called by joystick functions.  The function will then return whatever it
- *  returns if the joystick is not present.
- *
- *  @param[in] callback The new callback, or `NULL` to remove the currently set
- *  callback.
- *  @return The previously set callback, or `NULL` if no callback was set or the
- *  library had not been [initialized](@ref intro_init).
- *
- *  @callback_signature
- *  @code
- *  void function_name(int jid, int event)
- *  @endcode
- *  For more information about the callback parameters, see the
- *  [function pointer type](@ref GLFWjoystickfun).
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref joystick_event
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup input
- */
-GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);
-
-/*! @brief Adds the specified SDL_GameControllerDB gamepad mappings.
- *
- *  This function parses the specified ASCII encoded string and updates the
- *  internal list with any gamepad mappings it finds.  This string may
- *  contain either a single gamepad mapping or many mappings separated by
- *  newlines.  The parser supports the full format of the `gamecontrollerdb.txt`
- *  source file including empty lines and comments.
- *
- *  See @ref gamepad_mapping for a description of the format.
- *
- *  If there is already a gamepad mapping for a given GUID in the internal list,
- *  it will be replaced by the one passed to this function.  If the library is
- *  terminated and re-initialized the internal list will revert to the built-in
- *  default.
- *
- *  @param[in] string The string containing the gamepad mappings.
- *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_VALUE.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref gamepad
- *  @sa @ref glfwJoystickIsGamepad
- *  @sa @ref glfwGetGamepadName
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwUpdateGamepadMappings(const char* string);
-
-/*! @brief Returns the human-readable gamepad name for the specified joystick.
- *
- *  This function returns the human-readable name of the gamepad from the
- *  gamepad mapping assigned to the specified joystick.
- *
- *  If the specified joystick is not present or does not have a gamepad mapping
- *  this function will return `NULL` but will not generate an error.  Call
- *  @ref glfwJoystickPresent to check whether it is present regardless of
- *  whether it has a mapping.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @return The UTF-8 encoded name of the gamepad, or `NULL` if the
- *  joystick is not present, does not have a mapping or an
- *  [error](@ref error_handling) occurred.
- *
- *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the specified joystick is
- *  disconnected, the gamepad mappings are updated or the library is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref gamepad
- *  @sa @ref glfwJoystickIsGamepad
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI const char* glfwGetGamepadName(int jid);
-
-/*! @brief Retrieves the state of the specified joystick remapped as a gamepad.
- *
- *  This function retrieves the state of the specified joystick remapped to
- *  an Xbox-like gamepad.
- *
- *  If the specified joystick is not present or does not have a gamepad mapping
- *  this function will return `GLFW_FALSE` but will not generate an error.  Call
- *  @ref glfwJoystickPresent to check whether it is present regardless of
- *  whether it has a mapping.
- *
- *  The Guide button may not be available for input as it is often hooked by the
- *  system or the Steam client.
- *
- *  Not all devices have all the buttons or axes provided by @ref
- *  GLFWgamepadstate.  Unavailable buttons and axes will always report
- *  `GLFW_RELEASE` and 0.0 respectively.
- *
- *  @param[in] jid The [joystick](@ref joysticks) to query.
- *  @param[out] state The gamepad input state of the joystick.
- *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
- *  connected, it has no gamepad mapping or an [error](@ref error_handling)
- *  occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_ENUM.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref gamepad
- *  @sa @ref glfwUpdateGamepadMappings
- *  @sa @ref glfwJoystickIsGamepad
- *
- *  @since Added in version 3.3.
- *
- *  @ingroup input
- */
-GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate* state);
-
-/*! @brief Sets the clipboard to the specified string.
- *
- *  This function sets the system clipboard to the specified, UTF-8 encoded
- *  string.
- *
- *  @param[in] window Deprecated.  Any valid window or `NULL`.
- *  @param[in] string A UTF-8 encoded string.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The specified string is copied before this function
- *  returns.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref clipboard
- *  @sa @ref glfwGetClipboardString
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
-
-/*! @brief Returns the contents of the clipboard as a string.
- *
- *  This function returns the contents of the system clipboard, if it contains
- *  or is convertible to a UTF-8 encoded string.  If the clipboard is empty or
- *  if its contents cannot be converted, `NULL` is returned and a @ref
- *  GLFW_FORMAT_UNAVAILABLE error is generated.
- *
- *  @param[in] window Deprecated.  Any valid window or `NULL`.
- *  @return The contents of the clipboard as a UTF-8 encoded string, or `NULL`
- *  if an [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is valid until the next call to @ref
- *  glfwGetClipboardString or @ref glfwSetClipboardString, or until the library
- *  is terminated.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref clipboard
- *  @sa @ref glfwSetClipboardString
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup input
- */
-GLFWAPI const char* glfwGetClipboardString(GLFWwindow* window);
-
-/*! @brief Returns the GLFW time.
- *
- *  This function returns the current GLFW time, in seconds.  Unless the time
- *  has been set using @ref glfwSetTime it measures time elapsed since GLFW was
- *  initialized.
- *
- *  This function and @ref glfwSetTime are helper functions on top of @ref
- *  glfwGetTimerFrequency and @ref glfwGetTimerValue.
- *
- *  The resolution of the timer is system dependent, but is usually on the order
- *  of a few micro- or nanoseconds.  It uses the highest-resolution monotonic
- *  time source on each supported platform.
- *
- *  @return The current time, in seconds, or zero if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.  Reading and
- *  writing of the internal base time is not atomic, so it needs to be
- *  externally synchronized with calls to @ref glfwSetTime.
- *
- *  @sa @ref time
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup input
- */
-GLFWAPI double glfwGetTime(void);
-
-/*! @brief Sets the GLFW time.
- *
- *  This function sets the current GLFW time, in seconds.  The value must be
- *  a positive finite number less than or equal to 18446744073.0, which is
- *  approximately 584.5 years.
- *
- *  This function and @ref glfwGetTime are helper functions on top of @ref
- *  glfwGetTimerFrequency and @ref glfwGetTimerValue.
- *
- *  @param[in] time The new value, in seconds.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_INVALID_VALUE.
- *
- *  @remark The upper limit of GLFW time is calculated as
- *  floor((2<sup>64</sup> - 1) / 10<sup>9</sup>) and is due to implementations
- *  storing nanoseconds in 64 bits.  The limit may be increased in the future.
- *
- *  @thread_safety This function may be called from any thread.  Reading and
- *  writing of the internal base time is not atomic, so it needs to be
- *  externally synchronized with calls to @ref glfwGetTime.
- *
- *  @sa @ref time
- *
- *  @since Added in version 2.2.
- *
- *  @ingroup input
- */
-GLFWAPI void glfwSetTime(double time);
-
-/*! @brief Returns the current value of the raw timer.
- *
- *  This function returns the current value of the raw timer, measured in
- *  1&nbsp;/&nbsp;frequency seconds.  To get the frequency, call @ref
- *  glfwGetTimerFrequency.
- *
- *  @return The value of the timer, or zero if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref time
- *  @sa @ref glfwGetTimerFrequency
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup input
- */
-GLFWAPI uint64_t glfwGetTimerValue(void);
-
-/*! @brief Returns the frequency, in Hz, of the raw timer.
- *
- *  This function returns the frequency, in Hz, of the raw timer.
- *
- *  @return The frequency of the timer, in Hz, or zero if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref time
- *  @sa @ref glfwGetTimerValue
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup input
- */
-GLFWAPI uint64_t glfwGetTimerFrequency(void);
-
-/*! @brief Makes the context of the specified window current for the calling
- *  thread.
- *
- *  This function makes the OpenGL or OpenGL ES context of the specified window
- *  current on the calling thread.  A context must only be made current on
- *  a single thread at a time and each thread can have only a single current
- *  context at a time.
- *
- *  Making a context of a window current on a given thread will detach
- *  any user context which is current on that thread and visa versa.
- *
- *  When moving a context between threads, you must make it non-current on the
- *  old thread before making it current on the new one.
- *
- *  By default, making a context non-current implicitly forces a pipeline flush.
- *  On machines that support `GL_KHR_context_flush_control`, you can control
- *  whether a context performs this flush by setting the
- *  [GLFW_CONTEXT_RELEASE_BEHAVIOR](@ref GLFW_CONTEXT_RELEASE_BEHAVIOR_hint)
- *  hint.
- *
- *  The specified window must have an OpenGL or OpenGL ES context.  Specifying
- *  a window without a context will generate a @ref GLFW_NO_WINDOW_CONTEXT
- *  error.
- *
- *  @param[in] window The window whose context to make current, or `NULL` to
- *  detach the current context.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_NO_WINDOW_CONTEXT and @ref GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref context_current
- *  @sa @ref glfwGetCurrentContext
- *  @sa @ref context_current_user
- *  @sa @ref glfwMakeUserContextCurrent
- *  @sa @ref glfwGetCurrentUserContext
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup context
- */
-GLFWAPI void glfwMakeContextCurrent(GLFWwindow* window);
-
-/*! @brief Returns the window whose context is current on the calling thread.
- *
- *  This function returns the window whose OpenGL or OpenGL ES context is
- *  current on the calling thread.
- *
- *  @return The window whose context is current, or `NULL` if no window's
- *  context is current.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref context_current
- *  @sa @ref glfwMakeContextCurrent
- *
- *  @since Added in version 3.0.
- *
- *  @ingroup context
- */
-GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
-
-/*! @brief Swaps the front and back buffers of the specified window.
- *
- *  This function swaps the front and back buffers of the specified window when
- *  rendering with OpenGL or OpenGL ES.  If the swap interval is greater than
- *  zero, the GPU driver waits the specified number of screen updates before
- *  swapping the buffers.
- *
- *  The specified window must have an OpenGL or OpenGL ES context.  Specifying
- *  a window without a context will generate a @ref GLFW_NO_WINDOW_CONTEXT
- *  error.
- *
- *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
- *  see `vkQueuePresentKHR` instead.
- *
- *  @param[in] window The window whose buffers to swap.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_NO_WINDOW_CONTEXT and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark __EGL:__ The context of the specified window must be current on the
- *  calling thread.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref buffer_swap
- *  @sa @ref glfwSwapInterval
- *
- *  @since Added in version 1.0.
- *  @glfw3 Added window handle parameter.
- *
- *  @ingroup window
- */
-GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
-
-/*! @brief Sets the swap interval for the current context.
- *
- *  This function sets the swap interval for the current OpenGL or OpenGL ES
- *  context, i.e. the number of screen updates to wait from the time @ref
- *  glfwSwapBuffers was called before swapping the buffers and returning.  This
- *  is sometimes called _vertical synchronization_, _vertical retrace
- *  synchronization_ or just _vsync_.
- *
- *  A context that supports either of the `WGL_EXT_swap_control_tear` and
- *  `GLX_EXT_swap_control_tear` extensions also accepts _negative_ swap
- *  intervals, which allows the driver to swap immediately even if a frame
- *  arrives a little bit late.  You can check for these extensions with @ref
- *  glfwExtensionSupported.
- *
- *  A context must be current on the calling thread.  Calling this function
- *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
- *
- *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
- *  see the present mode of your swapchain instead.
- *
- *  @param[in] interval The minimum number of screen updates to wait for
- *  until the buffers are swapped by @ref glfwSwapBuffers.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_NO_CURRENT_CONTEXT and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark This function is not called during context creation, leaving the
- *  swap interval set to whatever is the default on that platform.  This is done
- *  because some swap interval extensions used by GLFW do not allow the swap
- *  interval to be reset to zero once it has been set to a non-zero value.
- *
- *  @remark Some GPU drivers do not honor the requested swap interval, either
- *  because of a user setting that overrides the application's request or due to
- *  bugs in the driver.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref buffer_swap
- *  @sa @ref glfwSwapBuffers
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup context
- */
-GLFWAPI void glfwSwapInterval(int interval);
-
-/*! @brief Returns whether the specified extension is available.
- *
- *  This function returns whether the specified
- *  [API extension](@ref context_glext) is supported by the current OpenGL or
- *  OpenGL ES context.  It searches both for client API extension and context
- *  creation API extensions.
- *
- *  A context must be current on the calling thread.  Calling this function
- *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
- *
- *  As this functions retrieves and searches one or more extension strings each
- *  call, it is recommended that you cache its results if it is going to be used
- *  frequently.  The extension strings will not change during the lifetime of
- *  a context, so there is no danger in doing this.
- *
- *  This function does not apply to Vulkan.  If you are using Vulkan, see @ref
- *  glfwGetRequiredInstanceExtensions, `vkEnumerateInstanceExtensionProperties`
- *  and `vkEnumerateDeviceExtensionProperties` instead.
- *
- *  @param[in] extension The ASCII encoded name of the extension.
- *  @return `GLFW_TRUE` if the extension is available, or `GLFW_FALSE`
- *  otherwise.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_NO_CURRENT_CONTEXT, @ref GLFW_INVALID_VALUE and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref context_glext
- *  @sa @ref glfwGetProcAddress
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup context
- */
-GLFWAPI int glfwExtensionSupported(const char* extension);
-
-/*! @brief Returns the address of the specified function for the current
- *  context.
- *
- *  This function returns the address of the specified OpenGL or OpenGL ES
- *  [core or extension function](@ref context_glext), if it is supported
- *  by the current context.
- *
- *  A context must be current on the calling thread.  Calling this function
- *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
- *
- *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
- *  see @ref glfwGetInstanceProcAddress, `vkGetInstanceProcAddr` and
- *  `vkGetDeviceProcAddr` instead.
- *
- *  @param[in] procname The ASCII encoded name of the function.
- *  @return The address of the function, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_NO_CURRENT_CONTEXT and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark The address of a given function is not guaranteed to be the same
- *  between contexts.
- *
- *  @remark This function may return a non-`NULL` address despite the
- *  associated version or extension not being available.  Always check the
- *  context version or extension string first.
- *
- *  @pointer_lifetime The returned function pointer is valid until the context
- *  is destroyed or the library is terminated.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref context_glext
- *  @sa @ref glfwExtensionSupported
- *
- *  @since Added in version 1.0.
- *
- *  @ingroup context
- */
-GLFWAPI GLFWglproc glfwGetProcAddress(const char* procname);
-
-/*! @brief Create a new OpenGL or OpenGL ES user context for a window
- *
- *  This function creates a new OpenGL or OpenGL ES user context for a
- *  window, which can be used to call OpenGL or OpenGL ES functions on
- *  another thread. For a valid user context the window must be created
- *  with a [GLFW_CLIENT_API](@ref GLFW_CLIENT_API_hint) other than
- *  `GLFW_NO_API`.
- *
- *  User context creation uses the window context and framebuffer related
- *  hints to ensure a valid context is created for that window, these hints
- *  should be the same at the time of user context creation as when the
- *  window was created.
- *
- *  Contexts share resources with the window context and with any other
- *  user context created for that window.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED,
- *  @ref GLFW_INVALID_VALUE the window parameter is `NULL`,
- *  @ref GLFW_NO_WINDOW_CONTEXT if the window has no OpenGL or
- *  OpenGL US context, and @ref GLFW_PLATFORM_ERROR.
- *
- *  @param[in] window The Window for which the user context is to be
- *  created.
- *  @return The handle of the user context created, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref context_user
- *  @sa @ref usercontext_creation
- *  @sa @ref glfwDestroyUserContext
- *  @sa @ref window_creation
- *  @sa @ref glfwCreateWindow
- *  @sa @ref glfwDestroyWindow
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup context
- */
-GLFWAPI GLFWusercontext* glfwCreateUserContext(GLFWwindow* window);
-
-/*! @brief Destroys the specified user context
- *
- *  This function destroys the specified user context.
- *  User contexts should be destroyed before destroying the
- *  window they were made with.
- *
- *  If the user context is current on the main thread, it is
- *  detached before being destroyed.
- *
- *  @param[in] context The user context to destroy.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_PLATFORM_ERROR.
- *
- *  @note The user context must not be current on any other
- *  thread when this function is called.
- *
- *  @reentrancy This function must not be called from a callback.
- *
- *  @thread_safety This function must only be called from the main thread.
- *
- *  @sa @ref context_user
- *  @sa @ref usercontext_creation
- *  @sa @ref glfwCreateUserContext
- *  @sa @ref window_creation
- *  @sa @ref glfwCreateWindow
- *  @sa @ref glfwDestroyWindow
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup context
- */
-GLFWAPI void glfwDestroyUserContext(GLFWusercontext* context);
-
-/*! @brief Makes the user context current for the calling thread.
- *
- *  This function makes the OpenGL or OpenGL ES context of the specified user
- *  context current on the calling thread.  A context must only be made current on
- *  a single thread at a time and each thread can have only a single current
- *  context at a time.
- *
- *  Making a user context current on a given thread will detach the context of
- *  any window which is current on that thread and visa versa.
- *
- *  When moving a context between threads, you must make it non-current on the
- *  old thread before making it current on the new one.
- *
- *  By default, making a context non-current implicitly forces a pipeline flush.
- *  On machines that support `GL_KHR_context_flush_control`, you can control
- *  whether a context performs this flush by setting the
- *  [GLFW_CONTEXT_RELEASE_BEHAVIOR](@ref GLFW_CONTEXT_RELEASE_BEHAVIOR_hint)
- *  hint.
- *
- *  @param[in] context The user context to make current, or `NULL` to
- *  detach the current context.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED,
- *  and @ref GLFW_PLATFORM_ERROR.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref context_user
- *  @sa @ref context_current_user
- *  @sa @ref glfwGetCurrentUserContext
- *  @sa @ref context_current
- *  @sa @ref glfwMakeContextCurrent
- *  @sa @ref glfwGetCurrentContext
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup context
- */
-GLFWAPI void glfwMakeUserContextCurrent(GLFWusercontext* context);
-
-/*! @brief Returns the current OpenGL or OpenGL ES user context
- *
- *  This function returns the user context which is current
- *  on the calling thread.
- *
- *  @return The user context current, or `NULL` if no user context
- *  is current.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref context_user
- *  @sa @ref context_current_user
- *  @sa @ref glfwMakeUserContextCurrent
- *  @sa @ref context_current
- *  @sa @ref glfwMakeContextCurrent
- *  @sa @ref glfwGetCurrentContext
- *
- *  @since Added in version 3.4.
- *
- *  @ingroup context
- */
-GLFWAPI GLFWusercontext* glfwGetCurrentUserContext(void);
-
-
-/*! @brief Returns whether the Vulkan loader and an ICD have been found.
- *
- *  This function returns whether the Vulkan loader and any minimally functional
- *  ICD have been found.
- *
- *  The availability of a Vulkan loader and even an ICD does not by itself
- *  guarantee that surface creation or even instance creation is possible.
- *  For example, on Fermi systems Nvidia will install an ICD that provides no
- *  actual Vulkan support.  Call @ref glfwGetRequiredInstanceExtensions to check
- *  whether the extensions necessary for Vulkan surface creation are available
- *  and @ref glfwGetPhysicalDevicePresentationSupport to check whether a queue
- *  family of a physical device supports image presentation.
- *
- *  @return `GLFW_TRUE` if Vulkan is minimally available, or `GLFW_FALSE`
- *  otherwise.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref vulkan_support
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup vulkan
- */
-GLFWAPI int glfwVulkanSupported(void);
-
-/*! @brief Returns the Vulkan instance extensions required by GLFW.
- *
- *  This function returns an array of names of Vulkan instance extensions required
- *  by GLFW for creating Vulkan surfaces for GLFW windows.  If successful, the
- *  list will always contain `VK_KHR_surface`, so if you don't require any
- *  additional extensions you can pass this list directly to the
- *  `VkInstanceCreateInfo` struct.
- *
- *  If Vulkan is not available on the machine, this function returns `NULL` and
- *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
- *  to check whether Vulkan is at least minimally available.
- *
- *  If Vulkan is available but no set of extensions allowing window surface
- *  creation was found, this function returns `NULL`.  You may still use Vulkan
- *  for off-screen rendering and compute work.
- *
- *  @param[out] count Where to store the number of extensions in the returned
- *  array.  This is set to zero if an error occurred.
- *  @return An array of ASCII encoded extension names, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_API_UNAVAILABLE.
- *
- *  @remark Additional extensions may be required by future versions of GLFW.
- *  You should check if any extensions you wish to enable are already in the
- *  returned array, as it is an error to specify an extension more than once in
- *  the `VkInstanceCreateInfo` struct.
- *
- *  @remark @macos GLFW currently supports both the `VK_MVK_macos_surface` and
- *  the newer `VK_EXT_metal_surface` extensions.
- *
- *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
- *  should not free it yourself.  It is guaranteed to be valid only until the
- *  library is terminated.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref vulkan_ext
- *  @sa @ref glfwCreateWindowSurface
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup vulkan
- */
-GLFWAPI const char** glfwGetRequiredInstanceExtensions(uint32_t* count);
+    typedef void (*GLFWwindowfocusfun)(GLFWwindow *window, int focused);
+
+    /*! @brief The function pointer type for window iconify callbacks.
+     *
+     *  This is the function pointer type for window iconify callbacks.  A window
+     *  iconify callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int iconified)
+     *  @endcode
+     *
+     *  @param[in] window The window that was iconified or restored.
+     *  @param[in] iconified `GLFW_TRUE` if the window was iconified, or
+     *  `GLFW_FALSE` if it was restored.
+     *
+     *  @sa @ref window_iconify
+     *  @sa @ref glfwSetWindowIconifyCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    typedef void (*GLFWwindowiconifyfun)(GLFWwindow *window, int iconified);
+
+    /*! @brief The function pointer type for window maximize callbacks.
+     *
+     *  This is the function pointer type for window maximize callbacks.  A window
+     *  maximize callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int maximized)
+     *  @endcode
+     *
+     *  @param[in] window The window that was maximized or restored.
+     *  @param[in] maximized `GLFW_TRUE` if the window was maximized, or
+     *  `GLFW_FALSE` if it was restored.
+     *
+     *  @sa @ref window_maximize
+     *  @sa glfwSetWindowMaximizeCallback
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    typedef void (*GLFWwindowmaximizefun)(GLFWwindow *window, int maximized);
+
+    /*! @brief The function pointer type for framebuffer size callbacks.
+     *
+     *  This is the function pointer type for framebuffer size callbacks.
+     *  A framebuffer size callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int width, int height)
+     *  @endcode
+     *
+     *  @param[in] window The window whose framebuffer was resized.
+     *  @param[in] width The new width, in pixels, of the framebuffer.
+     *  @param[in] height The new height, in pixels, of the framebuffer.
+     *
+     *  @sa @ref window_fbsize
+     *  @sa @ref glfwSetFramebufferSizeCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    typedef void (*GLFWframebuffersizefun)(GLFWwindow *window, int width, int height);
+
+    /*! @brief The function pointer type for window content scale callbacks.
+     *
+     *  This is the function pointer type for window content scale callbacks.
+     *  A window content scale callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, float xscale, float yscale)
+     *  @endcode
+     *
+     *  @param[in] window The window whose content scale changed.
+     *  @param[in] xscale The new x-axis content scale of the window.
+     *  @param[in] yscale The new y-axis content scale of the window.
+     *
+     *  @sa @ref window_scale
+     *  @sa @ref glfwSetWindowContentScaleCallback
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    typedef void (*GLFWwindowcontentscalefun)(GLFWwindow *window, float xscale, float yscale);
+
+    /*! @brief The function pointer type for mouse button callbacks.
+     *
+     *  This is the function pointer type for mouse button callback functions.
+     *  A mouse button callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int button, int action, int mods)
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] button The [mouse button](@ref buttons) that was pressed or
+     *  released.
+     *  @param[in] action One of `GLFW_PRESS` or `GLFW_RELEASE`.  Future releases
+     *  may add more actions.
+     *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+     *  held down.
+     *
+     *  @sa @ref input_mouse_button
+     *  @sa @ref glfwSetMouseButtonCallback
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle and modifier mask parameters.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWmousebuttonfun)(GLFWwindow *window, int button, int action, int mods);
+
+    /*! @brief The function pointer type for cursor position callbacks.
+     *
+     *  This is the function pointer type for cursor position callbacks.  A cursor
+     *  position callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, double xpos, double ypos);
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] xpos The new cursor x-coordinate, relative to the left edge of
+     *  the content area.
+     *  @param[in] ypos The new cursor y-coordinate, relative to the top edge of the
+     *  content area.
+     *
+     *  @sa @ref cursor_pos
+     *  @sa @ref glfwSetCursorPosCallback
+     *
+     *  @since Added in version 3.0.  Replaces `GLFWmouseposfun`.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWcursorposfun)(GLFWwindow *window, double xpos, double ypos);
+
+    /*! @brief The function pointer type for cursor enter/leave callbacks.
+     *
+     *  This is the function pointer type for cursor enter/leave callbacks.
+     *  A cursor enter/leave callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int entered)
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] entered `GLFW_TRUE` if the cursor entered the window's content
+     *  area, or `GLFW_FALSE` if it left it.
+     *
+     *  @sa @ref cursor_enter
+     *  @sa @ref glfwSetCursorEnterCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWcursorenterfun)(GLFWwindow *window, int entered);
+
+    /*! @brief The function pointer type for scroll callbacks.
+     *
+     *  This is the function pointer type for scroll callbacks.  A scroll callback
+     *  function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, double xoffset, double yoffset)
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] xoffset The scroll offset along the x-axis.
+     *  @param[in] yoffset The scroll offset along the y-axis.
+     *
+     *  @sa @ref scrolling
+     *  @sa @ref glfwSetScrollCallback
+     *
+     *  @since Added in version 3.0.  Replaces `GLFWmousewheelfun`.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWscrollfun)(GLFWwindow *window, double xoffset, double yoffset);
+
+    /*! @brief The function pointer type for keyboard key callbacks.
+     *
+     *  This is the function pointer type for keyboard key callbacks.  A keyboard
+     *  key callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] key The [keyboard key](@ref keys) that was pressed or released.
+     *  @param[in] scancode The system-specific scancode of the key.
+     *  @param[in] action `GLFW_PRESS`, `GLFW_RELEASE` or `GLFW_REPEAT`.  Future
+     *  releases may add more actions.
+     *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+     *  held down.
+     *
+     *  @sa @ref input_key
+     *  @sa @ref glfwSetKeyCallback
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle, scancode and modifier mask parameters.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWkeyfun)(GLFWwindow *window, int key, int scancode, int action, int mods);
+
+    /*! @brief The function pointer type for Unicode character callbacks.
+     *
+     *  This is the function pointer type for Unicode character callbacks.
+     *  A Unicode character callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, unsigned int codepoint)
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] codepoint The Unicode code point of the character.
+     *
+     *  @sa @ref input_char
+     *  @sa @ref glfwSetCharCallback
+     *
+     *  @since Added in version 2.4.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWcharfun)(GLFWwindow *window, unsigned int codepoint);
+
+    /*! @brief The function pointer type for Unicode character with modifiers
+     *  callbacks.
+     *
+     *  This is the function pointer type for Unicode character with modifiers
+     *  callbacks.  It is called for each input character, regardless of what
+     *  modifier keys are held down.  A Unicode character with modifiers callback
+     *  function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, unsigned int codepoint, int mods)
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] codepoint The Unicode code point of the character.
+     *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+     *  held down.
+     *
+     *  @sa @ref input_char
+     *  @sa @ref glfwSetCharModsCallback
+     *
+     *  @deprecated Scheduled for removal in version 4.0.
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWcharmodsfun)(GLFWwindow *window, unsigned int codepoint, int mods);
+
+    /*! @brief The function pointer type for path drop callbacks.
+     *
+     *  This is the function pointer type for path drop callbacks.  A path drop
+     *  callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWwindow* window, int path_count, const char* paths[])
+     *  @endcode
+     *
+     *  @param[in] window The window that received the event.
+     *  @param[in] path_count The number of dropped paths.
+     *  @param[in] paths The UTF-8 encoded file and/or directory path names.
+     *
+     *  @pointer_lifetime The path array and its strings are valid until the
+     *  callback function returns.
+     *
+     *  @sa @ref path_drop
+     *  @sa @ref glfwSetDropCallback
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWdropfun)(GLFWwindow *window, int path_count, const char *paths[]);
+
+    /*! @brief The function pointer type for monitor configuration callbacks.
+     *
+     *  This is the function pointer type for monitor configuration callbacks.
+     *  A monitor callback function has the following signature:
+     *  @code
+     *  void function_name(GLFWmonitor* monitor, int event)
+     *  @endcode
+     *
+     *  @param[in] monitor The monitor that was connected or disconnected.
+     *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
+     *  releases may add more events.
+     *
+     *  @sa @ref monitor_event
+     *  @sa @ref glfwSetMonitorCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    typedef void (*GLFWmonitorfun)(GLFWmonitor *monitor, int event);
+
+    /*! @brief The function pointer type for joystick configuration callbacks.
+     *
+     *  This is the function pointer type for joystick configuration callbacks.
+     *  A joystick configuration callback function has the following signature:
+     *  @code
+     *  void function_name(int jid, int event)
+     *  @endcode
+     *
+     *  @param[in] jid The joystick that was connected or disconnected.
+     *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.  Future
+     *  releases may add more events.
+     *
+     *  @sa @ref joystick_event
+     *  @sa @ref glfwSetJoystickCallback
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup input
+     */
+    typedef void (*GLFWjoystickfun)(int jid, int event);
+
+    /*! @brief Video mode type.
+     *
+     *  This describes a single video mode.
+     *
+     *  @sa @ref monitor_modes
+     *  @sa @ref glfwGetVideoMode
+     *  @sa @ref glfwGetVideoModes
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added refresh rate member.
+     *
+     *  @ingroup monitor
+     */
+    typedef struct GLFWvidmode
+    {
+        /*! The width, in screen coordinates, of the video mode.
+         */
+        int width;
+        /*! The height, in screen coordinates, of the video mode.
+         */
+        int height;
+        /*! The bit depth of the red channel of the video mode.
+         */
+        int redBits;
+        /*! The bit depth of the green channel of the video mode.
+         */
+        int greenBits;
+        /*! The bit depth of the blue channel of the video mode.
+         */
+        int blueBits;
+        /*! The refresh rate, in Hz, of the video mode.
+         */
+        int refreshRate;
+    } GLFWvidmode;
+
+    /*! @brief Gamma ramp.
+     *
+     *  This describes the gamma ramp for a monitor.
+     *
+     *  @sa @ref monitor_gamma
+     *  @sa @ref glfwGetGammaRamp
+     *  @sa @ref glfwSetGammaRamp
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    typedef struct GLFWgammaramp
+    {
+        /*! An array of value describing the response of the red channel.
+         */
+        unsigned short *red;
+        /*! An array of value describing the response of the green channel.
+         */
+        unsigned short *green;
+        /*! An array of value describing the response of the blue channel.
+         */
+        unsigned short *blue;
+        /*! The number of elements in each array.
+         */
+        unsigned int size;
+    } GLFWgammaramp;
+
+    /*! @brief Image data.
+     *
+     *  This describes a single 2D image.  See the documentation for each related
+     *  function what the expected pixel format is.
+     *
+     *  @sa @ref cursor_custom
+     *  @sa @ref window_icon
+     *
+     *  @since Added in version 2.1.
+     *  @glfw3 Removed format and bytes-per-pixel members.
+     *
+     *  @ingroup window
+     */
+    typedef struct GLFWimage
+    {
+        /*! The width, in pixels, of this image.
+         */
+        int width;
+        /*! The height, in pixels, of this image.
+         */
+        int height;
+        /*! The pixel data of this image, arranged left-to-right, top-to-bottom.
+         */
+        unsigned char *pixels;
+    } GLFWimage;
+
+    /*! @brief Gamepad input state
+     *
+     *  This describes the input state of a gamepad.
+     *
+     *  @sa @ref gamepad
+     *  @sa @ref glfwGetGamepadState
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    typedef struct GLFWgamepadstate
+    {
+        /*! The states of each [gamepad button](@ref gamepad_buttons), `GLFW_PRESS`
+         *  or `GLFW_RELEASE`.
+         */
+        unsigned char buttons[15];
+        /*! The states of each [gamepad axis](@ref gamepad_axes), in the range -1.0
+         *  to 1.0 inclusive.
+         */
+        float axes[6];
+    } GLFWgamepadstate;
+
+    /*! @brief
+     *
+     *  @sa @ref init_allocator
+     *  @sa @ref glfwInitAllocator
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup init
+     */
+    typedef struct GLFWallocator
+    {
+        GLFWallocatefun allocate;
+        GLFWreallocatefun reallocate;
+        GLFWdeallocatefun deallocate;
+        void *user;
+    } GLFWallocator;
+
+    /*************************************************************************
+     * GLFW API functions
+     *************************************************************************/
+
+    /*! @brief Initializes the GLFW library.
+     *
+     *  This function initializes the GLFW library.  Before most GLFW functions can
+     *  be used, GLFW must be initialized, and before an application terminates GLFW
+     *  should be terminated in order to free any resources allocated during or
+     *  after initialization.
+     *
+     *  If this function fails, it calls @ref glfwTerminate before returning.  If it
+     *  succeeds, you should call @ref glfwTerminate before the application exits.
+     *
+     *  Additional calls to this function after successful initialization but before
+     *  termination will return `GLFW_TRUE` immediately.
+     *
+     *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @macos This function will change the current directory of the
+     *  application to the `Contents/Resources` subdirectory of the application's
+     *  bundle, if present.  This can be disabled with the @ref
+     *  GLFW_COCOA_CHDIR_RESOURCES init hint.
+     *
+     *  @remark @macos This function will create the main menu and dock icon for the
+     *  application.  If GLFW finds a `MainMenu.nib` it is loaded and assumed to
+     *  contain a menu bar.  Otherwise a minimal menu bar is created manually with
+     *  common commands like Hide, Quit and About.  The About entry opens a minimal
+     *  about dialog with information from the application's bundle.  The menu bar
+     *  and dock icon can be disabled entirely with the @ref GLFW_COCOA_MENUBAR init
+     *  hint.
+     *
+     *  @remark @x11 This function will set the `LC_CTYPE` category of the
+     *  application locale according to the current environment if that category is
+     *  still "C".  This is because the "C" locale breaks Unicode text input.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref intro_init
+     *  @sa @ref glfwInitHint
+     *  @sa @ref glfwInitAllocator
+     *  @sa @ref glfwTerminate
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI int glfwInit(void);
+
+    /*! @brief Terminates the GLFW library.
+     *
+     *  This function destroys all remaining windows and cursors, restores any
+     *  modified gamma ramps and frees any other allocated resources.  Once this
+     *  function is called, you must again call @ref glfwInit successfully before
+     *  you will be able to use most GLFW functions.
+     *
+     *  If GLFW has been successfully initialized, this function should be called
+     *  before the application exits.  If initialization fails, there is no need to
+     *  call this function, as it is called by @ref glfwInit before it returns
+     *  failure.
+     *
+     *  This function has no effect if GLFW is not initialized.
+     *
+     *  @errors Possible errors include @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark This function may be called before @ref glfwInit.
+     *
+     *  @warning The contexts of any remaining windows must not be current on any
+     *  other thread when this function is called.
+     *
+     *  @reentrancy This function must not be called from a callback.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref intro_init
+     *  @sa @ref glfwInit
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI void glfwTerminate(void);
+
+    /*! @brief Sets the specified init hint to the desired value.
+     *
+     *  This function sets hints for the next initialization of GLFW.
+     *
+     *  The values you set hints to are never reset by GLFW, but they only take
+     *  effect during initialization.  Once GLFW has been initialized, any values
+     *  you set will be ignored until the library is terminated and initialized
+     *  again.
+     *
+     *  Some hints are platform specific.  These may be set on any platform but they
+     *  will only affect their specific platform.  Other platforms will ignore them.
+     *  Setting these hints requires no platform specific headers or functions.
+     *
+     *  @param[in] hint The [init hint](@ref init_hints) to set.
+     *  @param[in] value The new value of the init hint.
+     *
+     *  @errors Possible errors include @ref GLFW_INVALID_ENUM and @ref
+     *  GLFW_INVALID_VALUE.
+     *
+     *  @remarks This function may be called before @ref glfwInit.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa init_hints
+     *  @sa glfwInit
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI void glfwInitHint(int hint, int value);
+
+    /*! @brief Sets the init allocator to the desired value.
+     *
+     *  To use the default allocator, call this function with a `NULL` argument.
+     *
+     *  If you specify an allocator struct, every member must be a valid function
+     *  pointer.  If any member is `NULL`, this function emits @ref
+     *  GLFW_INVALID_VALUE and the init allocator is unchanged.
+     *
+     *  @param[in] allocator The allocator to use at the next initialization, or
+     *  `NULL` to use the default one.
+     *
+     *  @errors Possible errors include @ref GLFW_INVALID_VALUE.
+     *
+     *  @pointer_lifetime The specified allocator is copied before this function
+     *  returns.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref init_allocator
+     *  @sa @ref glfwInit
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI void glfwInitAllocator(const GLFWallocator *allocator);
+
+    /*! @brief Retrieves the version of the GLFW library.
+     *
+     *  This function retrieves the major, minor and revision numbers of the GLFW
+     *  library.  It is intended for when you are using GLFW as a shared library and
+     *  want to ensure that you are using the minimum required version.
+     *
+     *  Any or all of the version arguments may be `NULL`.
+     *
+     *  @param[out] major Where to store the major version number, or `NULL`.
+     *  @param[out] minor Where to store the minor version number, or `NULL`.
+     *  @param[out] rev Where to store the revision number, or `NULL`.
+     *
+     *  @errors None.
+     *
+     *  @remark This function may be called before @ref glfwInit.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref intro_version
+     *  @sa @ref glfwGetVersionString
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI void glfwGetVersion(int *major, int *minor, int *rev);
+
+    /*! @brief Returns a string describing the compile-time configuration.
+     *
+     *  This function returns the compile-time generated
+     *  [version string](@ref intro_version_string) of the GLFW library binary.  It
+     *  describes the version, platform, compiler and any platform-specific
+     *  compile-time options.  It should not be confused with the OpenGL or OpenGL
+     *  ES version string, queried with `glGetString`.
+     *
+     *  __Do not use the version string__ to parse the GLFW library version.  The
+     *  @ref glfwGetVersion function provides the version of the running library
+     *  binary in numerical format.
+     *
+     *  @return The ASCII encoded GLFW version string.
+     *
+     *  @errors None.
+     *
+     *  @remark This function may be called before @ref glfwInit.
+     *
+     *  @pointer_lifetime The returned string is static and compile-time generated.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref intro_version
+     *  @sa @ref glfwGetVersion
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI const char *glfwGetVersionString(void);
+
+    /*! @brief Returns and clears the last error for the calling thread.
+     *
+     *  This function returns and clears the [error code](@ref errors) of the last
+     *  error that occurred on the calling thread, and optionally a UTF-8 encoded
+     *  human-readable description of it.  If no error has occurred since the last
+     *  call, it returns @ref GLFW_NO_ERROR (zero) and the description pointer is
+     *  set to `NULL`.
+     *
+     *  @param[in] description Where to store the error description pointer, or `NULL`.
+     *  @return The last error code for the calling thread, or @ref GLFW_NO_ERROR
+     *  (zero).
+     *
+     *  @errors None.
+     *
+     *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is guaranteed to be valid only until the
+     *  next error occurs or the library is terminated.
+     *
+     *  @remark This function may be called before @ref glfwInit.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref error_handling
+     *  @sa @ref glfwSetErrorCallback
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI int glfwGetError(const char **description);
+
+    /*! @brief Sets the error callback.
+     *
+     *  This function sets the error callback, which is called with an error code
+     *  and a human-readable description each time a GLFW error occurs.
+     *
+     *  The error code is set before the callback is called.  Calling @ref
+     *  glfwGetError from the error callback will return the same value as the error
+     *  code argument.
+     *
+     *  The error callback is called on the thread where the error occurred.  If you
+     *  are using GLFW from multiple threads, your error callback needs to be
+     *  written accordingly.
+     *
+     *  Because the description string may have been generated specifically for that
+     *  error, it is not guaranteed to be valid after the callback has returned.  If
+     *  you wish to use it after the callback returns, you need to make a copy.
+     *
+     *  Once set, the error callback remains set even after the library has been
+     *  terminated.
+     *
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set.
+     *
+     *  @callback_signature
+     *  @code
+     *  void callback_name(int error_code, const char* description)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [callback pointer type](@ref GLFWerrorfun).
+     *
+     *  @errors None.
+     *
+     *  @remark This function may be called before @ref glfwInit.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref error_handling
+     *  @sa @ref glfwGetError
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup init
+     */
+    GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun callback);
+
+    /*! @brief Returns the currently connected monitors.
+     *
+     *  This function returns an array of handles for all currently connected
+     *  monitors.  The primary monitor is always first in the returned array.  If no
+     *  monitors were found, this function returns `NULL`.
+     *
+     *  @param[out] count Where to store the number of monitors in the returned
+     *  array.  This is set to zero if an error occurred.
+     *  @return An array of monitor handles, or `NULL` if no monitors were found or
+     *  if an [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is guaranteed to be valid only until the
+     *  monitor configuration changes or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_monitors
+     *  @sa @ref monitor_event
+     *  @sa @ref glfwGetPrimaryMonitor
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI GLFWmonitor **glfwGetMonitors(int *count);
+
+    /*! @brief Returns the primary monitor.
+     *
+     *  This function returns the primary monitor.  This is usually the monitor
+     *  where elements like the task bar or global menu bar are located.
+     *
+     *  @return The primary monitor, or `NULL` if no monitors were found or if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @remark The primary monitor is always first in the array returned by @ref
+     *  glfwGetMonitors.
+     *
+     *  @sa @ref monitor_monitors
+     *  @sa @ref glfwGetMonitors
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI GLFWmonitor *glfwGetPrimaryMonitor(void);
+
+    /*! @brief Returns the position of the monitor's viewport on the virtual screen.
+     *
+     *  This function returns the position, in screen coordinates, of the upper-left
+     *  corner of the specified monitor.
+     *
+     *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
+     *  non-`NULL` position arguments will be set to zero.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
+     *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_properties
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void glfwGetMonitorPos(GLFWmonitor *monitor, int *xpos, int *ypos);
+
+    /*! @brief Retrieves the work area of the monitor.
+     *
+     *  This function returns the position, in screen coordinates, of the upper-left
+     *  corner of the work area of the specified monitor along with the work area
+     *  size in screen coordinates. The work area is defined as the area of the
+     *  monitor not occluded by the operating system task bar where present. If no
+     *  task bar exists then the work area is the monitor resolution in screen
+     *  coordinates.
+     *
+     *  Any or all of the position and size arguments may be `NULL`.  If an error
+     *  occurs, all non-`NULL` position and size arguments will be set to zero.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
+     *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
+     *  @param[out] width Where to store the monitor width, or `NULL`.
+     *  @param[out] height Where to store the monitor height, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_workarea
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void glfwGetMonitorWorkarea(GLFWmonitor *monitor, int *xpos, int *ypos, int *width, int *height);
+
+    /*! @brief Returns the physical size of the monitor.
+     *
+     *  This function returns the size, in millimetres, of the display area of the
+     *  specified monitor.
+     *
+     *  Some systems do not provide accurate monitor size information, either
+     *  because the monitor
+     *  [EDID](https://en.wikipedia.org/wiki/Extended_display_identification_data)
+     *  data is incorrect or because the driver does not report it accurately.
+     *
+     *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+     *  non-`NULL` size arguments will be set to zero.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @param[out] widthMM Where to store the width, in millimetres, of the
+     *  monitor's display area, or `NULL`.
+     *  @param[out] heightMM Where to store the height, in millimetres, of the
+     *  monitor's display area, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @remark @win32 calculates the returned physical size from the
+     *  current resolution and system DPI instead of querying the monitor EDID data.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_properties
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor *monitor, int *widthMM, int *heightMM);
+
+    /*! @brief Retrieves the content scale for the specified monitor.
+     *
+     *  This function retrieves the content scale for the specified monitor.  The
+     *  content scale is the ratio between the current DPI and the platform's
+     *  default DPI.  This is especially important for text and any UI elements.  If
+     *  the pixel dimensions of your UI scaled by this look appropriate on your
+     *  machine then it should appear at a reasonable size on other machines
+     *  regardless of their DPI and scaling settings.  This relies on the system DPI
+     *  and scaling settings being somewhat correct.
+     *
+     *  The content scale may depend on both the monitor resolution and pixel
+     *  density and on user settings.  It may be very different from the raw DPI
+     *  calculated from the physical size and current resolution.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @param[out] xscale Where to store the x-axis content scale, or `NULL`.
+     *  @param[out] yscale Where to store the y-axis content scale, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_scale
+     *  @sa @ref glfwGetWindowContentScale
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void glfwGetMonitorContentScale(GLFWmonitor *monitor, float *xscale, float *yscale);
+
+    /*! @brief Returns the name of the specified monitor.
+     *
+     *  This function returns a human-readable name, encoded as UTF-8, of the
+     *  specified monitor.  The name typically reflects the make and model of the
+     *  monitor and is not guaranteed to be unique among the connected monitors.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @return The UTF-8 encoded name of the monitor, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified monitor is
+     *  disconnected or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_properties
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI const char *glfwGetMonitorName(GLFWmonitor *monitor);
+
+    /*! @brief Sets the user pointer of the specified monitor.
+     *
+     *  This function sets the user-defined pointer of the specified monitor.  The
+     *  current value is retained until the monitor is disconnected.  The initial
+     *  value is `NULL`.
+     *
+     *  This function may be called from the monitor callback, even for a monitor
+     *  that is being disconnected.
+     *
+     *  @param[in] monitor The monitor whose pointer to set.
+     *  @param[in] pointer The new value.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref monitor_userptr
+     *  @sa @ref glfwGetMonitorUserPointer
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void glfwSetMonitorUserPointer(GLFWmonitor *monitor, void *pointer);
+
+    /*! @brief Returns the user pointer of the specified monitor.
+     *
+     *  This function returns the current value of the user-defined pointer of the
+     *  specified monitor.  The initial value is `NULL`.
+     *
+     *  This function may be called from the monitor callback, even for a monitor
+     *  that is being disconnected.
+     *
+     *  @param[in] monitor The monitor whose pointer to return.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref monitor_userptr
+     *  @sa @ref glfwSetMonitorUserPointer
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void *glfwGetMonitorUserPointer(GLFWmonitor *monitor);
+
+    /*! @brief Sets the monitor configuration callback.
+     *
+     *  This function sets the monitor configuration callback, or removes the
+     *  currently set callback.  This is called when a monitor is connected to or
+     *  disconnected from the system.
+     *
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWmonitor* monitor, int event)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWmonitorfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_event
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI GLFWmonitorfun glfwSetMonitorCallback(GLFWmonitorfun callback);
+
+    /*! @brief Returns the available video modes for the specified monitor.
+     *
+     *  This function returns an array of all video modes supported by the specified
+     *  monitor.  The returned array is sorted in ascending order, first by color
+     *  bit depth (the sum of all channel depths), then by resolution area (the
+     *  product of width and height), then resolution width and finally by refresh
+     *  rate.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @param[out] count Where to store the number of video modes in the returned
+     *  array.  This is set to zero if an error occurred.
+     *  @return An array of video modes, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified monitor is
+     *  disconnected, this function is called again for that monitor or the library
+     *  is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_modes
+     *  @sa @ref glfwGetVideoMode
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Changed to return an array of modes for a specific monitor.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI const GLFWvidmode *glfwGetVideoModes(GLFWmonitor *monitor, int *count);
+
+    /*! @brief Returns the current mode of the specified monitor.
+     *
+     *  This function returns the current video mode of the specified monitor.  If
+     *  you have created a full screen window for that monitor, the return value
+     *  will depend on whether that window is iconified.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @return The current mode of the monitor, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified monitor is
+     *  disconnected or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_modes
+     *  @sa @ref glfwGetVideoModes
+     *
+     *  @since Added in version 3.0.  Replaces `glfwGetDesktopMode`.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI const GLFWvidmode *glfwGetVideoMode(GLFWmonitor *monitor);
+
+    /*! @brief Generates a gamma ramp and sets it for the specified monitor.
+     *
+     *  This function generates an appropriately sized gamma ramp from the specified
+     *  exponent and then calls @ref glfwSetGammaRamp with it.  The value must be
+     *  a finite number greater than zero.
+     *
+     *  The software controlled gamma ramp is applied _in addition_ to the hardware
+     *  gamma correction, which today is usually an approximation of sRGB gamma.
+     *  This means that setting a perfectly linear ramp, or gamma 1.0, will produce
+     *  the default (usually sRGB-like) behavior.
+     *
+     *  For gamma correct rendering with OpenGL or OpenGL ES, see the @ref
+     *  GLFW_SRGB_CAPABLE hint.
+     *
+     *  @param[in] monitor The monitor whose gamma ramp to set.
+     *  @param[in] gamma The desired exponent.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @wayland Gamma handling is a privileged protocol, this function
+     *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_gamma
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void glfwSetGamma(GLFWmonitor *monitor, float gamma);
+
+    /*! @brief Returns the current gamma ramp for the specified monitor.
+     *
+     *  This function returns the current gamma ramp of the specified monitor.
+     *
+     *  @param[in] monitor The monitor to query.
+     *  @return The current gamma ramp, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @wayland Gamma handling is a privileged protocol, this function
+     *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR while
+     *  returning `NULL`.
+     *
+     *  @pointer_lifetime The returned structure and its arrays are allocated and
+     *  freed by GLFW.  You should not free them yourself.  They are valid until the
+     *  specified monitor is disconnected, this function is called again for that
+     *  monitor or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_gamma
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI const GLFWgammaramp *glfwGetGammaRamp(GLFWmonitor *monitor);
+
+    /*! @brief Sets the current gamma ramp for the specified monitor.
+     *
+     *  This function sets the current gamma ramp for the specified monitor.  The
+     *  original gamma ramp for that monitor is saved by GLFW the first time this
+     *  function is called and is restored by @ref glfwTerminate.
+     *
+     *  The software controlled gamma ramp is applied _in addition_ to the hardware
+     *  gamma correction, which today is usually an approximation of sRGB gamma.
+     *  This means that setting a perfectly linear ramp, or gamma 1.0, will produce
+     *  the default (usually sRGB-like) behavior.
+     *
+     *  For gamma correct rendering with OpenGL or OpenGL ES, see the @ref
+     *  GLFW_SRGB_CAPABLE hint.
+     *
+     *  @param[in] monitor The monitor whose gamma ramp to set.
+     *  @param[in] ramp The gamma ramp to use.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark The size of the specified gamma ramp should match the size of the
+     *  current ramp for that monitor.
+     *
+     *  @remark @win32 The gamma ramp size must be 256.
+     *
+     *  @remark @wayland Gamma handling is a privileged protocol, this function
+     *  will thus never be implemented and emits @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The specified gamma ramp is copied before this function
+     *  returns.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref monitor_gamma
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup monitor
+     */
+    GLFWAPI void glfwSetGammaRamp(GLFWmonitor *monitor, const GLFWgammaramp *ramp);
+
+    /*! @brief Resets all window hints to their default values.
+     *
+     *  This function resets all window hints to their
+     *  [default values](@ref window_hints_values).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_hints
+     *  @sa @ref glfwWindowHint
+     *  @sa @ref glfwWindowHintString
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwDefaultWindowHints(void);
+
+    /*! @brief Sets the specified window hint to the desired value.
+     *
+     *  This function sets hints for the next call to @ref glfwCreateWindow.  The
+     *  hints, once set, retain their values until changed by a call to this
+     *  function or @ref glfwDefaultWindowHints, or until the library is terminated.
+     *
+     *  Only integer value hints can be set with this function.  String value hints
+     *  are set with @ref glfwWindowHintString.
+     *
+     *  This function does not check whether the specified hint values are valid.
+     *  If you set hints to invalid values this will instead be reported by the next
+     *  call to @ref glfwCreateWindow.
+     *
+     *  Some hints are platform specific.  These may be set on any platform but they
+     *  will only affect their specific platform.  Other platforms will ignore them.
+     *  Setting these hints requires no platform specific headers or functions.
+     *
+     *  @param[in] hint The [window hint](@ref window_hints) to set.
+     *  @param[in] value The new value of the window hint.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_hints
+     *  @sa @ref glfwWindowHintString
+     *  @sa @ref glfwDefaultWindowHints
+     *
+     *  @since Added in version 3.0.  Replaces `glfwOpenWindowHint`.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwWindowHint(int hint, int value);
+
+    /*! @brief Sets the specified window hint to the desired pointer value.
+     *
+     *  This function works in the same way as @ref glfwWindowHint, but sets pointer
+     *  values rather than integers.  Calling this function for hints that do not
+     *  expect a pointer value is an error.
+     *
+     *  @param[in] hint The pointer [window hint](@ref window_hints) to set.
+     *  @param[in] value The pointer value of the window hint.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_hints
+     *  @sa @ref glfwDefaultWindowHints
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwWindowHintPointer(int hint, void *value);
+
+    /*! @brief Sets the specified window hint to the desired value.
+     *
+     *  This function sets hints for the next call to @ref glfwCreateWindow.  The
+     *  hints, once set, retain their values until changed by a call to this
+     *  function or @ref glfwDefaultWindowHints, or until the library is terminated.
+     *
+     *  Only string type hints can be set with this function.  Integer value hints
+     *  are set with @ref glfwWindowHint.
+     *
+     *  This function does not check whether the specified hint values are valid.
+     *  If you set hints to invalid values this will instead be reported by the next
+     *  call to @ref glfwCreateWindow.
+     *
+     *  Some hints are platform specific.  These may be set on any platform but they
+     *  will only affect their specific platform.  Other platforms will ignore them.
+     *  Setting these hints requires no platform specific headers or functions.
+     *
+     *  @param[in] hint The [window hint](@ref window_hints) to set.
+     *  @param[in] value The new value of the window hint.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @pointer_lifetime The specified string is copied before this function
+     *  returns.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_hints
+     *  @sa @ref glfwWindowHint
+     *  @sa @ref glfwDefaultWindowHints
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwWindowHintString(int hint, const char *value);
+
+    /*! @brief Creates a window and its associated context.
+     *
+     *  This function creates a window and its associated OpenGL or OpenGL ES
+     *  context.  Most of the options controlling how the window and its context
+     *  should be created are specified with [window hints](@ref window_hints).
+     *
+     *  Successful creation does not change which context is current.  Before you
+     *  can use the newly created context, you need to
+     *  [make it current](@ref context_current).  For information about the `share`
+     *  parameter, see @ref context_sharing.
+     *
+     *  The created window, framebuffer and context may differ from what you
+     *  requested, as not all parameters and hints are
+     *  [hard constraints](@ref window_hints_hard).  This includes the size of the
+     *  window, especially for full screen windows.  To query the actual attributes
+     *  of the created window, framebuffer and context, see @ref
+     *  glfwGetWindowAttrib, @ref glfwGetWindowSize and @ref glfwGetFramebufferSize.
+     *
+     *  To create a full screen window, you need to specify the monitor the window
+     *  will cover.  If no monitor is specified, the window will be windowed mode.
+     *  Unless you have a way for the user to choose a specific monitor, it is
+     *  recommended that you pick the primary monitor.  For more information on how
+     *  to query connected monitors, see @ref monitor_monitors.
+     *
+     *  For full screen windows, the specified size becomes the resolution of the
+     *  window's _desired video mode_.  As long as a full screen window is not
+     *  iconified, the supported video mode most closely matching the desired video
+     *  mode is set for the specified monitor.  For more information about full
+     *  screen windows, including the creation of so called _windowed full screen_
+     *  or _borderless full screen_ windows, see @ref window_windowed_full_screen.
+     *
+     *  Once you have created the window, you can switch it between windowed and
+     *  full screen mode with @ref glfwSetWindowMonitor.  This will not affect its
+     *  OpenGL or OpenGL ES context.
+     *
+     *  By default, newly created windows use the placement recommended by the
+     *  window system.  To create the window at a specific position, make it
+     *  initially invisible using the [GLFW_VISIBLE](@ref GLFW_VISIBLE_hint) window
+     *  hint, set its [position](@ref window_pos) and then [show](@ref window_hide)
+     *  it.
+     *
+     *  As long as at least one full screen window is not iconified, the screensaver
+     *  is prohibited from starting.
+     *
+     *  Window systems put limits on window sizes.  Very large or very small window
+     *  dimensions may be overridden by the window system on creation.  Check the
+     *  actual [size](@ref window_size) after creation.
+     *
+     *  The [swap interval](@ref buffer_swap) is not set during window creation and
+     *  the initial value may vary depending on driver settings and defaults.
+     *
+     *  @param[in] width The desired width, in screen coordinates, of the window.
+     *  This must be greater than zero.
+     *  @param[in] height The desired height, in screen coordinates, of the window.
+     *  This must be greater than zero.
+     *  @param[in] title The initial, UTF-8 encoded window title.
+     *  @param[in] monitor The monitor to use for full screen mode, or `NULL` for
+     *  windowed mode.
+     *  @param[in] share The window whose context to share resources with, or `NULL`
+     *  to not share resources.
+     *  @return The handle of the created window, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE, @ref GLFW_API_UNAVAILABLE, @ref
+     *  GLFW_VERSION_UNAVAILABLE, @ref GLFW_FORMAT_UNAVAILABLE and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @win32 Window creation will fail if the Microsoft GDI software
+     *  OpenGL implementation is the only one available.
+     *
+     *  @remark @win32 If the executable has an icon resource named `GLFW_ICON,` it
+     *  will be set as the initial icon for the window.  If no such icon is present,
+     *  the `IDI_APPLICATION` icon will be used instead.  To set a different icon,
+     *  see @ref glfwSetWindowIcon.
+     *
+     *  @remark @win32 The context to share resources with must not be current on
+     *  any other thread.
+     *
+     *  @remark @macos The OS only supports core profile contexts for OpenGL
+     *  versions 3.2 and later.  Before creating an OpenGL context of version 3.2 or
+     *  later you must set the [GLFW_OPENGL_PROFILE](@ref GLFW_OPENGL_PROFILE_hint)
+     *  hint accordingly.  OpenGL 3.0 and 3.1 contexts are not supported at all
+     *  on macOS.
+     *
+     *  @remark @macos The GLFW window has no icon, as it is not a document
+     *  window, but the dock icon will be the same as the application bundle's icon.
+     *  For more information on bundles, see the
+     *  [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/)
+     *  in the Mac Developer Library.
+     *
+     *  @remark @macos On OS X 10.10 and later the window frame will not be rendered
+     *  at full resolution on Retina displays unless the
+     *  [GLFW_COCOA_RETINA_FRAMEBUFFER](@ref GLFW_COCOA_RETINA_FRAMEBUFFER_hint)
+     *  hint is `GLFW_TRUE` and the `NSHighResolutionCapable` key is enabled in the
+     *  application bundle's `Info.plist`.  For more information, see
+     *  [High Resolution Guidelines for OS X](https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html)
+     *  in the Mac Developer Library.  The GLFW test and example programs use
+     *  a custom `Info.plist` template for this, which can be found as
+     *  `CMake/Info.plist.in` in the source tree.
+     *
+     *  @remark @macos When activating frame autosaving with
+     *  [GLFW_COCOA_FRAME_NAME](@ref GLFW_COCOA_FRAME_NAME_hint), the specified
+     *  window size and position may be overridden by previously saved values.
+     *
+     *  @remark @x11 Some window managers will not respect the placement of
+     *  initially hidden windows.
+     *
+     *  @remark @x11 Due to the asynchronous nature of X11, it may take a moment for
+     *  a window to reach its requested state.  This means you may not be able to
+     *  query the final size, position or other attributes directly after window
+     *  creation.
+     *
+     *  @remark @x11 The class part of the `WM_CLASS` window property will by
+     *  default be set to the window title passed to this function.  The instance
+     *  part will use the contents of the `RESOURCE_NAME` environment variable, if
+     *  present and not empty, or fall back to the window title.  Set the
+     *  [GLFW_X11_CLASS_NAME](@ref GLFW_X11_CLASS_NAME_hint) and
+     *  [GLFW_X11_INSTANCE_NAME](@ref GLFW_X11_INSTANCE_NAME_hint) window hints to
+     *  override this.
+     *
+     *  @remark @wayland Compositors should implement the xdg-decoration protocol
+     *  for GLFW to decorate the window properly.  If this protocol isn't
+     *  supported, or if the compositor prefers client-side decorations, a very
+     *  simple fallback frame will be drawn using the wp_viewporter protocol.  A
+     *  compositor can still emit close, maximize or fullscreen events, using for
+     *  instance a keybind mechanism.  If neither of these protocols is supported,
+     *  the window won't be decorated.
+     *
+     *  @remark @wayland A full screen window will not attempt to change the mode,
+     *  no matter what the requested size or refresh rate.
+     *
+     *  @remark @wayland Screensaver inhibition requires the idle-inhibit protocol
+     *  to be implemented in the user's compositor.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_creation
+     *  @sa @ref glfwDestroyWindow
+     *
+     *  @since Added in version 3.0.  Replaces `glfwOpenWindow`.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindow *glfwCreateWindow(int width, int height, const char *title, GLFWmonitor *monitor, GLFWwindow *share);
+
+    /*! @brief Destroys the specified window and its context.
+     *
+     *  This function destroys the specified window and its context.  On calling
+     *  this function, no further callbacks will be called for that window.
+     *
+     *  If the context of the specified window is current on the main thread, it is
+     *  detached before being destroyed.
+     *
+     *  @param[in] window The window to destroy.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @note The context of the specified window must not be current on any other
+     *  thread when this function is called.
+     *
+     *  @reentrancy This function must not be called from a callback.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_creation
+     *  @sa @ref glfwCreateWindow
+     *
+     *  @since Added in version 3.0.  Replaces `glfwCloseWindow`.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwDestroyWindow(GLFWwindow *window);
+
+    /*! @brief Checks the close flag of the specified window.
+     *
+     *  This function returns the value of the close flag of the specified window.
+     *
+     *  @param[in] window The window to query.
+     *  @return The value of the close flag.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref window_close
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI int glfwWindowShouldClose(GLFWwindow *window);
+
+    /*! @brief Sets the close flag of the specified window.
+     *
+     *  This function sets the value of the close flag of the specified window.
+     *  This can be used to override the user's attempt to close the window, or
+     *  to signal that it should be closed.
+     *
+     *  @param[in] window The window whose flag to change.
+     *  @param[in] value The new value.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref window_close
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowShouldClose(GLFWwindow *window, int value);
+
+    /*! @brief Sets the title of the specified window.
+     *
+     *  This function sets the window title, encoded as UTF-8, of the specified
+     *  window.
+     *
+     *  @param[in] window The window whose title to change.
+     *  @param[in] title The UTF-8 encoded window title.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @macos The window title will not be updated until the next time you
+     *  process events.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_title
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowTitle(GLFWwindow *window, const char *title);
+
+    /*! @brief Sets the icon for the specified window.
+     *
+     *  This function sets the icon of the specified window.  If passed an array of
+     *  candidate images, those of or closest to the sizes desired by the system are
+     *  selected.  If no images are specified, the window reverts to its default
+     *  icon.
+     *
+     *  The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
+     *  bits per channel with the red channel first.  They are arranged canonically
+     *  as packed sequential rows, starting from the top-left corner.
+     *
+     *  The desired image sizes varies depending on platform and system settings.
+     *  The selected images will be rescaled as needed.  Good sizes include 16x16,
+     *  32x32 and 48x48.
+     *
+     *  @param[in] window The window whose icon to set.
+     *  @param[in] count The number of images in the specified array, or zero to
+     *  revert to the default window icon.
+     *  @param[in] images The images to create the icon from.  This is ignored if
+     *  count is zero.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+     *
+     *  @pointer_lifetime The specified image data is copied before this function
+     *  returns.
+     *
+     *  @remark @macos Regular windows do not have icons on macOS.  This function
+     *  will emit @ref GLFW_FEATURE_UNAVAILABLE.  The dock icon will be the same as
+     *  the application bundle's icon.  For more information on bundles, see the
+     *  [Bundle Programming Guide](https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFBundles/)
+     *  in the Mac Developer Library.
+     *
+     *  @remark @wayland There is no existing protocol to change an icon, the
+     *  window will thus inherit the one defined in the application's desktop file.
+     *  This function will emit @ref GLFW_FEATURE_UNAVAILABLE.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_icon
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowIcon(GLFWwindow *window, int count, const GLFWimage *images);
+
+    /*! @brief Retrieves the position of the content area of the specified window.
+     *
+     *  This function retrieves the position, in screen coordinates, of the
+     *  upper-left corner of the content area of the specified window.
+     *
+     *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
+     *  non-`NULL` position arguments will be set to zero.
+     *
+     *  @param[in] window The window to query.
+     *  @param[out] xpos Where to store the x-coordinate of the upper-left corner of
+     *  the content area, or `NULL`.
+     *  @param[out] ypos Where to store the y-coordinate of the upper-left corner of
+     *  the content area, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+     *
+     *  @remark @wayland There is no way for an application to retrieve the global
+     *  position of its windows.  This function will emit @ref
+     *  GLFW_FEATURE_UNAVAILABLE.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_pos
+     *  @sa @ref glfwSetWindowPos
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwGetWindowPos(GLFWwindow *window, int *xpos, int *ypos);
+
+    /*! @brief Sets the position of the content area of the specified window.
+     *
+     *  This function sets the position, in screen coordinates, of the upper-left
+     *  corner of the content area of the specified windowed mode window.  If the
+     *  window is a full screen window, this function does nothing.
+     *
+     *  __Do not use this function__ to move an already visible window unless you
+     *  have very good reasons for doing so, as it will confuse and annoy the user.
+     *
+     *  The window manager may put limits on what positions are allowed.  GLFW
+     *  cannot and should not override these limits.
+     *
+     *  @param[in] window The window to query.
+     *  @param[in] xpos The x-coordinate of the upper-left corner of the content area.
+     *  @param[in] ypos The y-coordinate of the upper-left corner of the content area.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+     *
+     *  @remark @wayland There is no way for an application to set the global
+     *  position of its windows.  This function will emit @ref
+     *  GLFW_FEATURE_UNAVAILABLE.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_pos
+     *  @sa @ref glfwGetWindowPos
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowPos(GLFWwindow *window, int xpos, int ypos);
+
+    /*! @brief Retrieves the size of the content area of the specified window.
+     *
+     *  This function retrieves the size, in screen coordinates, of the content area
+     *  of the specified window.  If you wish to retrieve the size of the
+     *  framebuffer of the window in pixels, see @ref glfwGetFramebufferSize.
+     *
+     *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+     *  non-`NULL` size arguments will be set to zero.
+     *
+     *  @param[in] window The window whose size to retrieve.
+     *  @param[out] width Where to store the width, in screen coordinates, of the
+     *  content area, or `NULL`.
+     *  @param[out] height Where to store the height, in screen coordinates, of the
+     *  content area, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_size
+     *  @sa @ref glfwSetWindowSize
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwGetWindowSize(GLFWwindow *window, int *width, int *height);
+
+    /*! @brief Sets the size limits of the specified window.
+     *
+     *  This function sets the size limits of the content area of the specified
+     *  window.  If the window is full screen, the size limits only take effect
+     *  once it is made windowed.  If the window is not resizable, this function
+     *  does nothing.
+     *
+     *  The size limits are applied immediately to a windowed mode window and may
+     *  cause it to be resized.
+     *
+     *  The maximum dimensions must be greater than or equal to the minimum
+     *  dimensions and all must be greater than or equal to zero.
+     *
+     *  @param[in] window The window to set limits for.
+     *  @param[in] minwidth The minimum width, in screen coordinates, of the content
+     *  area, or `GLFW_DONT_CARE`.
+     *  @param[in] minheight The minimum height, in screen coordinates, of the
+     *  content area, or `GLFW_DONT_CARE`.
+     *  @param[in] maxwidth The maximum width, in screen coordinates, of the content
+     *  area, or `GLFW_DONT_CARE`.
+     *  @param[in] maxheight The maximum height, in screen coordinates, of the
+     *  content area, or `GLFW_DONT_CARE`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark If you set size limits and an aspect ratio that conflict, the
+     *  results are undefined.
+     *
+     *  @remark @wayland The size limits will not be applied until the window is
+     *  actually resized, either by the user or by the compositor.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_sizelimits
+     *  @sa @ref glfwSetWindowAspectRatio
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow *window, int minwidth, int minheight, int maxwidth, int maxheight);
+
+    /*! @brief Sets the aspect ratio of the specified window.
+     *
+     *  This function sets the required aspect ratio of the content area of the
+     *  specified window.  If the window is full screen, the aspect ratio only takes
+     *  effect once it is made windowed.  If the window is not resizable, this
+     *  function does nothing.
+     *
+     *  The aspect ratio is specified as a numerator and a denominator and both
+     *  values must be greater than zero.  For example, the common 16:9 aspect ratio
+     *  is specified as 16 and 9, respectively.
+     *
+     *  If the numerator and denominator is set to `GLFW_DONT_CARE` then the aspect
+     *  ratio limit is disabled.
+     *
+     *  The aspect ratio is applied immediately to a windowed mode window and may
+     *  cause it to be resized.
+     *
+     *  @param[in] window The window to set limits for.
+     *  @param[in] numer The numerator of the desired aspect ratio, or
+     *  `GLFW_DONT_CARE`.
+     *  @param[in] denom The denominator of the desired aspect ratio, or
+     *  `GLFW_DONT_CARE`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark If you set size limits and an aspect ratio that conflict, the
+     *  results are undefined.
+     *
+     *  @remark @wayland The aspect ratio will not be applied until the window is
+     *  actually resized, either by the user or by the compositor.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_sizelimits
+     *  @sa @ref glfwSetWindowSizeLimits
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow *window, int numer, int denom);
+
+    /*! @brief Sets the size of the content area of the specified window.
+     *
+     *  This function sets the size, in screen coordinates, of the content area of
+     *  the specified window.
+     *
+     *  For full screen windows, this function updates the resolution of its desired
+     *  video mode and switches to the video mode closest to it, without affecting
+     *  the window's context.  As the context is unaffected, the bit depths of the
+     *  framebuffer remain unchanged.
+     *
+     *  If you wish to update the refresh rate of the desired video mode in addition
+     *  to its resolution, see @ref glfwSetWindowMonitor.
+     *
+     *  The window manager may put limits on what sizes are allowed.  GLFW cannot
+     *  and should not override these limits.
+     *
+     *  @param[in] window The window to resize.
+     *  @param[in] width The desired width, in screen coordinates, of the window
+     *  content area.
+     *  @param[in] height The desired height, in screen coordinates, of the window
+     *  content area.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @wayland A full screen window will not attempt to change the mode,
+     *  no matter what the requested size.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_size
+     *  @sa @ref glfwGetWindowSize
+     *  @sa @ref glfwSetWindowMonitor
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowSize(GLFWwindow *window, int width, int height);
+
+    /*! @brief Retrieves the size of the framebuffer of the specified window.
+     *
+     *  This function retrieves the size, in pixels, of the framebuffer of the
+     *  specified window.  If you wish to retrieve the size of the window in screen
+     *  coordinates, see @ref glfwGetWindowSize.
+     *
+     *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+     *  non-`NULL` size arguments will be set to zero.
+     *
+     *  @param[in] window The window whose framebuffer to query.
+     *  @param[out] width Where to store the width, in pixels, of the framebuffer,
+     *  or `NULL`.
+     *  @param[out] height Where to store the height, in pixels, of the framebuffer,
+     *  or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_fbsize
+     *  @sa @ref glfwSetFramebufferSizeCallback
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwGetFramebufferSize(GLFWwindow *window, int *width, int *height);
+
+    /*! @brief Retrieves the size of the frame of the window.
+     *
+     *  This function retrieves the size, in screen coordinates, of each edge of the
+     *  frame of the specified window.  This size includes the title bar, if the
+     *  window has one.  The size of the frame may vary depending on the
+     *  [window-related hints](@ref window_hints_wnd) used to create it.
+     *
+     *  Because this function retrieves the size of each window frame edge and not
+     *  the offset along a particular coordinate axis, the retrieved values will
+     *  always be zero or positive.
+     *
+     *  Any or all of the size arguments may be `NULL`.  If an error occurs, all
+     *  non-`NULL` size arguments will be set to zero.
+     *
+     *  @param[in] window The window whose frame size to query.
+     *  @param[out] left Where to store the size, in screen coordinates, of the left
+     *  edge of the window frame, or `NULL`.
+     *  @param[out] top Where to store the size, in screen coordinates, of the top
+     *  edge of the window frame, or `NULL`.
+     *  @param[out] right Where to store the size, in screen coordinates, of the
+     *  right edge of the window frame, or `NULL`.
+     *  @param[out] bottom Where to store the size, in screen coordinates, of the
+     *  bottom edge of the window frame, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_size
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwGetWindowFrameSize(GLFWwindow *window, int *left, int *top, int *right, int *bottom);
+
+    /*! @brief Retrieves the content scale for the specified window.
+     *
+     *  This function retrieves the content scale for the specified window.  The
+     *  content scale is the ratio between the current DPI and the platform's
+     *  default DPI.  This is especially important for text and any UI elements.  If
+     *  the pixel dimensions of your UI scaled by this look appropriate on your
+     *  machine then it should appear at a reasonable size on other machines
+     *  regardless of their DPI and scaling settings.  This relies on the system DPI
+     *  and scaling settings being somewhat correct.
+     *
+     *  On systems where each monitors can have its own content scale, the window
+     *  content scale will depend on which monitor the system considers the window
+     *  to be on.
+     *
+     *  @param[in] window The window to query.
+     *  @param[out] xscale Where to store the x-axis content scale, or `NULL`.
+     *  @param[out] yscale Where to store the y-axis content scale, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_scale
+     *  @sa @ref glfwSetWindowContentScaleCallback
+     *  @sa @ref glfwGetMonitorContentScale
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwGetWindowContentScale(GLFWwindow *window, float *xscale, float *yscale);
+
+    /*! @brief Returns the opacity of the whole window.
+     *
+     *  This function returns the opacity of the window, including any decorations.
+     *
+     *  The opacity (or alpha) value is a positive finite number between zero and
+     *  one, where zero is fully transparent and one is fully opaque.  If the system
+     *  does not support whole window transparency, this function always returns one.
+     *
+     *  The initial opacity value for newly created windows is one.
+     *
+     *  @param[in] window The window to query.
+     *  @return The opacity value of the specified window.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_transparency
+     *  @sa @ref glfwSetWindowOpacity
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI float glfwGetWindowOpacity(GLFWwindow *window);
+
+    /*! @brief Sets the opacity of the whole window.
+     *
+     *  This function sets the opacity of the window, including any decorations.
+     *
+     *  The opacity (or alpha) value is a positive finite number between zero and
+     *  one, where zero is fully transparent and one is fully opaque.
+     *
+     *  The initial opacity value for newly created windows is one.
+     *
+     *  A window created with framebuffer transparency may not use whole window
+     *  transparency.  The results of doing this are undefined.
+     *
+     *  @param[in] window The window to set the opacity for.
+     *  @param[in] opacity The desired opacity of the specified window.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+     *
+     *  @remark @wayland There is no way to set an opacity factor for a window.
+     *  This function will emit @ref GLFW_FEATURE_UNAVAILABLE.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_transparency
+     *  @sa @ref glfwGetWindowOpacity
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowOpacity(GLFWwindow *window, float opacity);
+
+    /*! @brief Iconifies the specified window.
+     *
+     *  This function iconifies (minimizes) the specified window if it was
+     *  previously restored.  If the window is already iconified, this function does
+     *  nothing.
+     *
+     *  If the specified window is a full screen window, the original monitor
+     *  resolution is restored until the window is restored.
+     *
+     *  @param[in] window The window to iconify.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @wayland Once a window is iconified, @ref glfwRestoreWindow won’t
+     *  be able to restore it.  This is a design decision of the xdg-shell
+     *  protocol.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_iconify
+     *  @sa @ref glfwRestoreWindow
+     *  @sa @ref glfwMaximizeWindow
+     *
+     *  @since Added in version 2.1.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwIconifyWindow(GLFWwindow *window);
+
+    /*! @brief Restores the specified window.
+     *
+     *  This function restores the specified window if it was previously iconified
+     *  (minimized) or maximized.  If the window is already restored, this function
+     *  does nothing.
+     *
+     *  If the specified window is a full screen window, the resolution chosen for
+     *  the window is restored on the selected monitor.
+     *
+     *  @param[in] window The window to restore.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_iconify
+     *  @sa @ref glfwIconifyWindow
+     *  @sa @ref glfwMaximizeWindow
+     *
+     *  @since Added in version 2.1.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwRestoreWindow(GLFWwindow *window);
+
+    /*! @brief Maximizes the specified window.
+     *
+     *  This function maximizes the specified window if it was previously not
+     *  maximized.  If the window is already maximized, this function does nothing.
+     *
+     *  If the specified window is a full screen window, this function does nothing.
+     *
+     *  @param[in] window The window to maximize.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @par Thread Safety
+     *  This function may only be called from the main thread.
+     *
+     *  @sa @ref window_iconify
+     *  @sa @ref glfwIconifyWindow
+     *  @sa @ref glfwRestoreWindow
+     *
+     *  @since Added in GLFW 3.2.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwMaximizeWindow(GLFWwindow *window);
+
+    /*! @brief Makes the specified window visible.
+     *
+     *  This function makes the specified window visible if it was previously
+     *  hidden.  If the window is already visible or is in full screen mode, this
+     *  function does nothing.
+     *
+     *  By default, windowed mode windows are focused when shown
+     *  Set the [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_hint) window hint
+     *  to change this behavior for all newly created windows, or change the
+     *  behavior for an existing window with @ref glfwSetWindowAttrib.
+     *
+     *  @param[in] window The window to make visible.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_hide
+     *  @sa @ref glfwHideWindow
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwShowWindow(GLFWwindow *window);
+
+    /*! @brief Hides the specified window.
+     *
+     *  This function hides the specified window if it was previously visible.  If
+     *  the window is already hidden or is in full screen mode, this function does
+     *  nothing.
+     *
+     *  @param[in] window The window to hide.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_hide
+     *  @sa @ref glfwShowWindow
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwHideWindow(GLFWwindow *window);
+
+    /*! @brief Brings the specified window to front and sets input focus.
+     *
+     *  This function brings the specified window to front and sets input focus.
+     *  The window should already be visible and not iconified.
+     *
+     *  By default, both windowed and full screen mode windows are focused when
+     *  initially created.  Set the [GLFW_FOCUSED](@ref GLFW_FOCUSED_hint) to
+     *  disable this behavior.
+     *
+     *  Also by default, windowed mode windows are focused when shown
+     *  with @ref glfwShowWindow. Set the
+     *  [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_hint) to disable this behavior.
+     *
+     *  __Do not use this function__ to steal focus from other applications unless
+     *  you are certain that is what the user wants.  Focus stealing can be
+     *  extremely disruptive.
+     *
+     *  For a less disruptive way of getting the user's attention, see
+     *  [attention requests](@ref window_attention).
+     *
+     *  @param[in] window The window to give input focus.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_PLATFORM_ERROR and @ref GLFW_FEATURE_UNAVAILABLE (see remarks).
+     *
+     *  @remark @wayland It is not possible for an application to set the input
+     *  focus.  This function will emit @ref GLFW_FEATURE_UNAVAILABLE.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_focus
+     *  @sa @ref window_attention
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwFocusWindow(GLFWwindow *window);
+
+    /*! @brief Requests user attention to the specified window.
+     *
+     *  This function requests user attention to the specified window.  On
+     *  platforms where this is not supported, attention is requested to the
+     *  application as a whole.
+     *
+     *  Once the user has given attention, usually by focusing the window or
+     *  application, the system will end the request automatically.
+     *
+     *  @param[in] window The window to request attention to.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @macos Attention is requested to the application as a whole, not the
+     *  specific window.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_attention
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwRequestWindowAttention(GLFWwindow *window);
+
+    /*! @brief Returns the monitor that the window uses for full screen mode.
+     *
+     *  This function returns the handle of the monitor that the specified window is
+     *  in full screen on.
+     *
+     *  @param[in] window The window to query.
+     *  @return The monitor, or `NULL` if the window is in windowed mode or an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_monitor
+     *  @sa @ref glfwSetWindowMonitor
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWmonitor *glfwGetWindowMonitor(GLFWwindow *window);
+
+    /*! @brief Sets the mode, monitor, video mode and placement of a window.
+     *
+     *  This function sets the monitor that the window uses for full screen mode or,
+     *  if the monitor is `NULL`, makes it windowed mode.
+     *
+     *  When setting a monitor, this function updates the width, height and refresh
+     *  rate of the desired video mode and switches to the video mode closest to it.
+     *  The window position is ignored when setting a monitor.
+     *
+     *  When the monitor is `NULL`, the position, width and height are used to
+     *  place the window content area.  The refresh rate is ignored when no monitor
+     *  is specified.
+     *
+     *  If you only wish to update the resolution of a full screen window or the
+     *  size of a windowed mode window, see @ref glfwSetWindowSize.
+     *
+     *  When a window transitions from full screen to windowed mode, this function
+     *  restores any previous window settings such as whether it is decorated,
+     *  floating, resizable, has size or aspect ratio limits, etc.
+     *
+     *  @param[in] window The window whose monitor, size or video mode to set.
+     *  @param[in] monitor The desired monitor, or `NULL` to set windowed mode.
+     *  @param[in] xpos The desired x-coordinate of the upper-left corner of the
+     *  content area.
+     *  @param[in] ypos The desired y-coordinate of the upper-left corner of the
+     *  content area.
+     *  @param[in] width The desired with, in screen coordinates, of the content
+     *  area or video mode.
+     *  @param[in] height The desired height, in screen coordinates, of the content
+     *  area or video mode.
+     *  @param[in] refreshRate The desired refresh rate, in Hz, of the video mode,
+     *  or `GLFW_DONT_CARE`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark The OpenGL or OpenGL ES context will not be destroyed or otherwise
+     *  affected by any resizing or mode switching, although you may need to update
+     *  your viewport if the framebuffer size has changed.
+     *
+     *  @remark @wayland The desired window position is ignored, as there is no way
+     *  for an application to set this property.
+     *
+     *  @remark @wayland Setting the window to full screen will not attempt to
+     *  change the mode, no matter what the requested size or refresh rate.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_monitor
+     *  @sa @ref window_full_screen
+     *  @sa @ref glfwGetWindowMonitor
+     *  @sa @ref glfwSetWindowSize
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowMonitor(GLFWwindow *window, GLFWmonitor *monitor, int xpos, int ypos, int width, int height, int refreshRate);
+
+    /*! @brief Returns an attribute of the specified window.
+     *
+     *  This function returns the value of an attribute of the specified window or
+     *  its OpenGL or OpenGL ES context.
+     *
+     *  @param[in] window The window to query.
+     *  @param[in] attrib The [window attribute](@ref window_attribs) whose value to
+     *  return.
+     *  @return The value of the attribute, or zero if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark Framebuffer related hints are not window attributes.  See @ref
+     *  window_attribs_fb for more information.
+     *
+     *  @remark Zero is a valid value for many window and context related
+     *  attributes so you cannot use a return value of zero as an indication of
+     *  errors.  However, this function should not fail as long as it is passed
+     *  valid arguments and the library has been [initialized](@ref intro_init).
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_attribs
+     *  @sa @ref glfwSetWindowAttrib
+     *
+     *  @since Added in version 3.0.  Replaces `glfwGetWindowParam` and
+     *  `glfwGetGLVersion`.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI int glfwGetWindowAttrib(GLFWwindow *window, int attrib);
+
+    /*! @brief Sets an attribute of the specified window.
+     *
+     *  This function sets the value of an attribute of the specified window.
+     *
+     *  The supported attributes are [GLFW_DECORATED](@ref GLFW_DECORATED_attrib),
+     *  [GLFW_RESIZABLE](@ref GLFW_RESIZABLE_attrib),
+     *  [GLFW_FLOATING](@ref GLFW_FLOATING_attrib),
+     *  [GLFW_AUTO_ICONIFY](@ref GLFW_AUTO_ICONIFY_attrib) and
+     *  [GLFW_FOCUS_ON_SHOW](@ref GLFW_FOCUS_ON_SHOW_attrib).
+     *  [GLFW_MOUSE_PASSTHROUGH](@ref GLFW_MOUSE_PASSTHROUGH_attrib)
+     *
+     *  Some of these attributes are ignored for full screen windows.  The new
+     *  value will take effect if the window is later made windowed.
+     *
+     *  Some of these attributes are ignored for windowed mode windows.  The new
+     *  value will take effect if the window is later made full screen.
+     *
+     *  @param[in] window The window to set the attribute for.
+     *  @param[in] attrib A supported window attribute.
+     *  @param[in] value `GLFW_TRUE` or `GLFW_FALSE`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM, @ref GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark Calling @ref glfwGetWindowAttrib will always return the latest
+     *  value, even if that value is ignored by the current mode of the window.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_attribs
+     *  @sa @ref glfwGetWindowAttrib
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowAttrib(GLFWwindow *window, int attrib, int value);
+
+    /*! @brief Sets the user pointer of the specified window.
+     *
+     *  This function sets the user-defined pointer of the specified window.  The
+     *  current value is retained until the window is destroyed.  The initial value
+     *  is `NULL`.
+     *
+     *  @param[in] window The window whose pointer to set.
+     *  @param[in] pointer The new value.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref window_userptr
+     *  @sa @ref glfwGetWindowUserPointer
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSetWindowUserPointer(GLFWwindow *window, void *pointer);
+
+    /*! @brief Returns the user pointer of the specified window.
+     *
+     *  This function returns the current value of the user-defined pointer of the
+     *  specified window.  The initial value is `NULL`.
+     *
+     *  @param[in] window The window whose pointer to return.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref window_userptr
+     *  @sa @ref glfwSetWindowUserPointer
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void *glfwGetWindowUserPointer(GLFWwindow *window);
+
+    /*! @brief Sets the position callback for the specified window.
+     *
+     *  This function sets the position callback of the specified window, which is
+     *  called when the window is moved.  The callback is provided with the
+     *  position, in screen coordinates, of the upper-left corner of the content
+     *  area of the window.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int xpos, int ypos)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowposfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @remark @wayland This callback will never be called, as there is no way for
+     *  an application to know its global position.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_pos
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow *window, GLFWwindowposfun callback);
+
+    /*! @brief Sets the size callback for the specified window.
+     *
+     *  This function sets the size callback of the specified window, which is
+     *  called when the window is resized.  The callback is provided with the size,
+     *  in screen coordinates, of the content area of the window.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int width, int height)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowsizefun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_size
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter and return value.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow *window, GLFWwindowsizefun callback);
+
+    /*! @brief Sets the close callback for the specified window.
+     *
+     *  This function sets the close callback of the specified window, which is
+     *  called when the user attempts to close the window, for example by clicking
+     *  the close widget in the title bar.
+     *
+     *  The close flag is set before this callback is called, but you can modify it
+     *  at any time with @ref glfwSetWindowShouldClose.
+     *
+     *  The close callback is not triggered by @ref glfwDestroyWindow.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowclosefun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @remark @macos Selecting Quit from the application menu will trigger the
+     *  close callback for all windows.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_close
+     *
+     *  @since Added in version 2.5.
+     *  @glfw3 Added window handle parameter and return value.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow *window, GLFWwindowclosefun callback);
+
+    /*! @brief Sets the refresh callback for the specified window.
+     *
+     *  This function sets the refresh callback of the specified window, which is
+     *  called when the content area of the window needs to be redrawn, for example
+     *  if the window has been exposed after having been covered by another window.
+     *
+     *  On compositing window systems such as Aero, Compiz, Aqua or Wayland, where
+     *  the window contents are saved off-screen, this callback may be called only
+     *  very infrequently or never at all.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window);
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowrefreshfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_refresh
+     *
+     *  @since Added in version 2.5.
+     *  @glfw3 Added window handle parameter and return value.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow *window, GLFWwindowrefreshfun callback);
+
+    /*! @brief Sets the focus callback for the specified window.
+     *
+     *  This function sets the focus callback of the specified window, which is
+     *  called when the window gains or loses input focus.
+     *
+     *  After the focus callback is called for a window that lost input focus,
+     *  synthetic key and mouse button release events will be generated for all such
+     *  that had been pressed.  For more information, see @ref glfwSetKeyCallback
+     *  and @ref glfwSetMouseButtonCallback.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int focused)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowfocusfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_focus
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow *window, GLFWwindowfocusfun callback);
+
+    /*! @brief Sets the iconify callback for the specified window.
+     *
+     *  This function sets the iconification callback of the specified window, which
+     *  is called when the window is iconified or restored.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int iconified)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowiconifyfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_iconify
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow *window, GLFWwindowiconifyfun callback);
+
+    /*! @brief Sets the maximize callback for the specified window.
+     *
+     *  This function sets the maximization callback of the specified window, which
+     *  is called when the window is maximized or restored.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int maximized)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowmaximizefun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_maximize
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow *window, GLFWwindowmaximizefun callback);
+
+    /*! @brief Sets the framebuffer resize callback for the specified window.
+     *
+     *  This function sets the framebuffer resize callback of the specified window,
+     *  which is called when the framebuffer of the specified window is resized.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int width, int height)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWframebuffersizefun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_fbsize
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow *window, GLFWframebuffersizefun callback);
+
+    /*! @brief Sets the window content scale callback for the specified window.
+     *
+     *  This function sets the window content scale callback of the specified window,
+     *  which is called when the content scale of the specified window changes.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, float xscale, float yscale)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWwindowcontentscalefun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref window_scale
+     *  @sa @ref glfwGetWindowContentScale
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(GLFWwindow *window, GLFWwindowcontentscalefun callback);
+
+    /*! @brief Processes all pending events.
+     *
+     *  This function processes only those events that are already in the event
+     *  queue and then returns immediately.  Processing events will cause the window
+     *  and input callbacks associated with those events to be called.
+     *
+     *  On some platforms, a window move, resize or menu operation will cause event
+     *  processing to block.  This is due to how event processing is designed on
+     *  those platforms.  You can use the
+     *  [window refresh callback](@ref window_refresh) to redraw the contents of
+     *  your window when necessary during such operations.
+     *
+     *  Do not assume that callbacks you set will _only_ be called in response to
+     *  event processing functions like this one.  While it is necessary to poll for
+     *  events, window systems that require GLFW to register callbacks of its own
+     *  can pass events to GLFW in response to many window system function calls.
+     *  GLFW will pass those events on to the application callbacks before
+     *  returning.
+     *
+     *  Event processing is not required for joystick input to work.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @reentrancy This function must not be called from a callback.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref events
+     *  @sa @ref glfwWaitEvents
+     *  @sa @ref glfwWaitEventsTimeout
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwPollEvents(void);
+
+    /*! @brief Waits until events are queued and processes them.
+     *
+     *  This function puts the calling thread to sleep until at least one event is
+     *  available in the event queue.  Once one or more events are available,
+     *  it behaves exactly like @ref glfwPollEvents, i.e. the events in the queue
+     *  are processed and the function then returns immediately.  Processing events
+     *  will cause the window and input callbacks associated with those events to be
+     *  called.
+     *
+     *  Since not all events are associated with callbacks, this function may return
+     *  without a callback having been called even if you are monitoring all
+     *  callbacks.
+     *
+     *  On some platforms, a window move, resize or menu operation will cause event
+     *  processing to block.  This is due to how event processing is designed on
+     *  those platforms.  You can use the
+     *  [window refresh callback](@ref window_refresh) to redraw the contents of
+     *  your window when necessary during such operations.
+     *
+     *  Do not assume that callbacks you set will _only_ be called in response to
+     *  event processing functions like this one.  While it is necessary to poll for
+     *  events, window systems that require GLFW to register callbacks of its own
+     *  can pass events to GLFW in response to many window system function calls.
+     *  GLFW will pass those events on to the application callbacks before
+     *  returning.
+     *
+     *  Event processing is not required for joystick input to work.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @reentrancy This function must not be called from a callback.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref events
+     *  @sa @ref glfwPollEvents
+     *  @sa @ref glfwWaitEventsTimeout
+     *
+     *  @since Added in version 2.5.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwWaitEvents(void);
+
+    /*! @brief Waits with timeout until events are queued and processes them.
+     *
+     *  This function puts the calling thread to sleep until at least one event is
+     *  available in the event queue, or until the specified timeout is reached.  If
+     *  one or more events are available, it behaves exactly like @ref
+     *  glfwPollEvents, i.e. the events in the queue are processed and the function
+     *  then returns immediately.  Processing events will cause the window and input
+     *  callbacks associated with those events to be called.
+     *
+     *  The timeout value must be a positive finite number.
+     *
+     *  Since not all events are associated with callbacks, this function may return
+     *  without a callback having been called even if you are monitoring all
+     *  callbacks.
+     *
+     *  On some platforms, a window move, resize or menu operation will cause event
+     *  processing to block.  This is due to how event processing is designed on
+     *  those platforms.  You can use the
+     *  [window refresh callback](@ref window_refresh) to redraw the contents of
+     *  your window when necessary during such operations.
+     *
+     *  Do not assume that callbacks you set will _only_ be called in response to
+     *  event processing functions like this one.  While it is necessary to poll for
+     *  events, window systems that require GLFW to register callbacks of its own
+     *  can pass events to GLFW in response to many window system function calls.
+     *  GLFW will pass those events on to the application callbacks before
+     *  returning.
+     *
+     *  Event processing is not required for joystick input to work.
+     *
+     *  @param[in] timeout The maximum amount of time, in seconds, to wait.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_VALUE and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @reentrancy This function must not be called from a callback.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref events
+     *  @sa @ref glfwPollEvents
+     *  @sa @ref glfwWaitEvents
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwWaitEventsTimeout(double timeout);
+
+    /*! @brief Posts an empty event to the event queue.
+     *
+     *  This function posts an empty event from the current thread to the event
+     *  queue, causing @ref glfwWaitEvents or @ref glfwWaitEventsTimeout to return.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref events
+     *  @sa @ref glfwWaitEvents
+     *  @sa @ref glfwWaitEventsTimeout
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwPostEmptyEvent(void);
+
+    /*! @brief Returns the value of an input option for the specified window.
+     *
+     *  This function returns the value of an input option for the specified window.
+     *  The mode must be one of @ref GLFW_CURSOR, @ref GLFW_STICKY_KEYS,
+     *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS or
+     *  @ref GLFW_RAW_MOUSE_MOTION.
+     *
+     *  @param[in] window The window to query.
+     *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
+     *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
+     *  `GLFW_RAW_MOUSE_MOTION`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref glfwSetInputMode
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwGetInputMode(GLFWwindow *window, int mode);
+
+    /*! @brief Sets an input option for the specified window.
+     *
+     *  This function sets an input mode option for the specified window.  The mode
+     *  must be one of @ref GLFW_CURSOR, @ref GLFW_STICKY_KEYS,
+     *  @ref GLFW_STICKY_MOUSE_BUTTONS, @ref GLFW_LOCK_KEY_MODS or
+     *  @ref GLFW_RAW_MOUSE_MOTION.
+     *
+     *  If the mode is `GLFW_CURSOR`, the value must be one of the following cursor
+     *  modes:
+     *  - `GLFW_CURSOR_NORMAL` makes the cursor visible and behaving normally.
+     *  - `GLFW_CURSOR_HIDDEN` makes the cursor invisible when it is over the
+     *    content area of the window but does not restrict the cursor from leaving.
+     *  - `GLFW_CURSOR_DISABLED` hides and grabs the cursor, providing virtual
+     *    and unlimited cursor movement.  This is useful for implementing for
+     *    example 3D camera controls.
+     *
+     *  If the mode is `GLFW_STICKY_KEYS`, the value must be either `GLFW_TRUE` to
+     *  enable sticky keys, or `GLFW_FALSE` to disable it.  If sticky keys are
+     *  enabled, a key press will ensure that @ref glfwGetKey returns `GLFW_PRESS`
+     *  the next time it is called even if the key had been released before the
+     *  call.  This is useful when you are only interested in whether keys have been
+     *  pressed but not when or in which order.
+     *
+     *  If the mode is `GLFW_STICKY_MOUSE_BUTTONS`, the value must be either
+     *  `GLFW_TRUE` to enable sticky mouse buttons, or `GLFW_FALSE` to disable it.
+     *  If sticky mouse buttons are enabled, a mouse button press will ensure that
+     *  @ref glfwGetMouseButton returns `GLFW_PRESS` the next time it is called even
+     *  if the mouse button had been released before the call.  This is useful when
+     *  you are only interested in whether mouse buttons have been pressed but not
+     *  when or in which order.
+     *
+     *  If the mode is `GLFW_LOCK_KEY_MODS`, the value must be either `GLFW_TRUE` to
+     *  enable lock key modifier bits, or `GLFW_FALSE` to disable them.  If enabled,
+     *  callbacks that receive modifier bits will also have the @ref
+     *  GLFW_MOD_CAPS_LOCK bit set when the event was generated with Caps Lock on,
+     *  and the @ref GLFW_MOD_NUM_LOCK bit when Num Lock was on.
+     *
+     *  If the mode is `GLFW_RAW_MOUSE_MOTION`, the value must be either `GLFW_TRUE`
+     *  to enable raw (unscaled and unaccelerated) mouse motion when the cursor is
+     *  disabled, or `GLFW_FALSE` to disable it.  If raw motion is not supported,
+     *  attempting to set this will emit @ref GLFW_FEATURE_UNAVAILABLE.  Call @ref
+     *  glfwRawMouseMotionSupported to check for support.
+     *
+     *  @param[in] window The window whose input mode to set.
+     *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS`,
+     *  `GLFW_STICKY_MOUSE_BUTTONS`, `GLFW_LOCK_KEY_MODS` or
+     *  `GLFW_RAW_MOUSE_MOTION`.
+     *  @param[in] value The new value of the specified input mode.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM, @ref GLFW_PLATFORM_ERROR and @ref
+     *  GLFW_FEATURE_UNAVAILABLE (see above).
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref glfwGetInputMode
+     *
+     *  @since Added in version 3.0.  Replaces `glfwEnable` and `glfwDisable`.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwSetInputMode(GLFWwindow *window, int mode, int value);
+
+    /*! @brief Returns whether raw mouse motion is supported.
+     *
+     *  This function returns whether raw mouse motion is supported on the current
+     *  system.  This status does not change after GLFW has been initialized so you
+     *  only need to check this once.  If you attempt to enable raw motion on
+     *  a system that does not support it, @ref GLFW_PLATFORM_ERROR will be emitted.
+     *
+     *  Raw mouse motion is closer to the actual motion of the mouse across
+     *  a surface.  It is not affected by the scaling and acceleration applied to
+     *  the motion of the desktop cursor.  That processing is suitable for a cursor
+     *  while raw motion is better for controlling for example a 3D camera.  Because
+     *  of this, raw mouse motion is only provided when the cursor is disabled.
+     *
+     *  @return `GLFW_TRUE` if raw mouse motion is supported on the current machine,
+     *  or `GLFW_FALSE` otherwise.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref raw_mouse_motion
+     *  @sa @ref glfwSetInputMode
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwRawMouseMotionSupported(void);
+
+    /*! @brief Returns the layout-specific name of the specified printable key.
+     *
+     *  This function returns the name of the specified printable key, encoded as
+     *  UTF-8.  This is typically the character that key would produce without any
+     *  modifier keys, intended for displaying key bindings to the user.  For dead
+     *  keys, it is typically the diacritic it would add to a character.
+     *
+     *  __Do not use this function__ for [text input](@ref input_char).  You will
+     *  break text input for many languages even if it happens to work for yours.
+     *
+     *  If the key is `GLFW_KEY_UNKNOWN`, the scancode is used to identify the key,
+     *  otherwise the scancode is ignored.  If you specify a non-printable key, or
+     *  `GLFW_KEY_UNKNOWN` and a scancode that maps to a non-printable key, this
+     *  function returns `NULL` but does not emit an error.
+     *
+     *  This behavior allows you to always pass in the arguments in the
+     *  [key callback](@ref input_key) without modification.
+     *
+     *  The printable keys are:
+     *  - `GLFW_KEY_APOSTROPHE`
+     *  - `GLFW_KEY_COMMA`
+     *  - `GLFW_KEY_MINUS`
+     *  - `GLFW_KEY_PERIOD`
+     *  - `GLFW_KEY_SLASH`
+     *  - `GLFW_KEY_SEMICOLON`
+     *  - `GLFW_KEY_EQUAL`
+     *  - `GLFW_KEY_LEFT_BRACKET`
+     *  - `GLFW_KEY_RIGHT_BRACKET`
+     *  - `GLFW_KEY_BACKSLASH`
+     *  - `GLFW_KEY_WORLD_1`
+     *  - `GLFW_KEY_WORLD_2`
+     *  - `GLFW_KEY_0` to `GLFW_KEY_9`
+     *  - `GLFW_KEY_A` to `GLFW_KEY_Z`
+     *  - `GLFW_KEY_KP_0` to `GLFW_KEY_KP_9`
+     *  - `GLFW_KEY_KP_DECIMAL`
+     *  - `GLFW_KEY_KP_DIVIDE`
+     *  - `GLFW_KEY_KP_MULTIPLY`
+     *  - `GLFW_KEY_KP_SUBTRACT`
+     *  - `GLFW_KEY_KP_ADD`
+     *  - `GLFW_KEY_KP_EQUAL`
+     *
+     *  Names for printable keys depend on keyboard layout, while names for
+     *  non-printable keys are the same across layouts but depend on the application
+     *  language and should be localized along with other user interface text.
+     *
+     *  @param[in] key The key to query, or `GLFW_KEY_UNKNOWN`.
+     *  @param[in] scancode The scancode of the key to query.
+     *  @return The UTF-8 encoded, layout-specific name of the key, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark The contents of the returned string may change when a keyboard
+     *  layout change event is received.
+     *
+     *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref input_key_name
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const char *glfwGetKeyName(int key, int scancode);
+
+    /*! @brief Returns the platform-specific scancode of the specified key.
+     *
+     *  This function returns the platform-specific scancode of the specified key.
+     *
+     *  If the key is `GLFW_KEY_UNKNOWN` or does not exist on the keyboard this
+     *  method will return `-1`.
+     *
+     *  @param[in] key Any [named key](@ref keys).
+     *  @return The platform-specific scancode for the key, or `-1` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref input_key
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwGetKeyScancode(int key);
+
+    /*! @brief Returns the last reported state of a keyboard key for the specified
+     *  window.
+     *
+     *  This function returns the last state reported for the specified key to the
+     *  specified window.  The returned state is one of `GLFW_PRESS` or
+     *  `GLFW_RELEASE`.  The higher-level action `GLFW_REPEAT` is only reported to
+     *  the key callback.
+     *
+     *  If the @ref GLFW_STICKY_KEYS input mode is enabled, this function returns
+     *  `GLFW_PRESS` the first time you call it for a key that was pressed, even if
+     *  that key has already been released.
+     *
+     *  The key functions deal with physical keys, with [key tokens](@ref keys)
+     *  named after their use on the standard US keyboard layout.  If you want to
+     *  input text, use the Unicode character callback instead.
+     *
+     *  The [modifier key bit masks](@ref mods) are not key tokens and cannot be
+     *  used with this function.
+     *
+     *  __Do not use this function__ to implement [text input](@ref input_char).
+     *
+     *  @param[in] window The desired window.
+     *  @param[in] key The desired [keyboard key](@ref keys).  `GLFW_KEY_UNKNOWN` is
+     *  not a valid key for this function.
+     *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref input_key
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwGetKey(GLFWwindow *window, int key);
+
+    /*! @brief Returns the last reported state of a mouse button for the specified
+     *  window.
+     *
+     *  This function returns the last state reported for the specified mouse button
+     *  to the specified window.  The returned state is one of `GLFW_PRESS` or
+     *  `GLFW_RELEASE`.
+     *
+     *  If the @ref GLFW_STICKY_MOUSE_BUTTONS input mode is enabled, this function
+     *  returns `GLFW_PRESS` the first time you call it for a mouse button that was
+     *  pressed, even if that mouse button has already been released.
+     *
+     *  @param[in] window The desired window.
+     *  @param[in] button The desired [mouse button](@ref buttons).
+     *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref input_mouse_button
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwGetMouseButton(GLFWwindow *window, int button);
+
+    /*! @brief Retrieves the position of the cursor relative to the content area of
+     *  the window.
+     *
+     *  This function returns the position of the cursor, in screen coordinates,
+     *  relative to the upper-left corner of the content area of the specified
+     *  window.
+     *
+     *  If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
+     *  position is unbounded and limited only by the minimum and maximum values of
+     *  a `double`.
+     *
+     *  The coordinate can be converted to their integer equivalents with the
+     *  `floor` function.  Casting directly to an integer type works for positive
+     *  coordinates, but fails for negative ones.
+     *
+     *  Any or all of the position arguments may be `NULL`.  If an error occurs, all
+     *  non-`NULL` position arguments will be set to zero.
+     *
+     *  @param[in] window The desired window.
+     *  @param[out] xpos Where to store the cursor x-coordinate, relative to the
+     *  left edge of the content area, or `NULL`.
+     *  @param[out] ypos Where to store the cursor y-coordinate, relative to the to
+     *  top edge of the content area, or `NULL`.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_pos
+     *  @sa @ref glfwSetCursorPos
+     *
+     *  @since Added in version 3.0.  Replaces `glfwGetMousePos`.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwGetCursorPos(GLFWwindow *window, double *xpos, double *ypos);
+
+    /*! @brief Sets the position of the cursor, relative to the content area of the
+     *  window.
+     *
+     *  This function sets the position, in screen coordinates, of the cursor
+     *  relative to the upper-left corner of the content area of the specified
+     *  window.  The window must have input focus.  If the window does not have
+     *  input focus when this function is called, it fails silently.
+     *
+     *  __Do not use this function__ to implement things like camera controls.  GLFW
+     *  already provides the `GLFW_CURSOR_DISABLED` cursor mode that hides the
+     *  cursor, transparently re-centers it and provides unconstrained cursor
+     *  motion.  See @ref glfwSetInputMode for more information.
+     *
+     *  If the cursor mode is `GLFW_CURSOR_DISABLED` then the cursor position is
+     *  unconstrained and limited only by the minimum and maximum values of
+     *  a `double`.
+     *
+     *  @param[in] window The desired window.
+     *  @param[in] xpos The desired x-coordinate, relative to the left edge of the
+     *  content area.
+     *  @param[in] ypos The desired y-coordinate, relative to the top edge of the
+     *  content area.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @wayland This function will only work when the cursor mode is
+     *  `GLFW_CURSOR_DISABLED`, otherwise it will do nothing.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_pos
+     *  @sa @ref glfwGetCursorPos
+     *
+     *  @since Added in version 3.0.  Replaces `glfwSetMousePos`.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwSetCursorPos(GLFWwindow *window, double xpos, double ypos);
+
+    /*! @brief Creates a custom cursor.
+     *
+     *  Creates a new custom cursor image that can be set for a window with @ref
+     *  glfwSetCursor.  The cursor can be destroyed with @ref glfwDestroyCursor.
+     *  Any remaining cursors are destroyed by @ref glfwTerminate.
+     *
+     *  The pixels are 32-bit, little-endian, non-premultiplied RGBA, i.e. eight
+     *  bits per channel with the red channel first.  They are arranged canonically
+     *  as packed sequential rows, starting from the top-left corner.
+     *
+     *  The cursor hotspot is specified in pixels, relative to the upper-left corner
+     *  of the cursor image.  Like all other coordinate systems in GLFW, the X-axis
+     *  points to the right and the Y-axis points down.
+     *
+     *  @param[in] image The desired cursor image.
+     *  @param[in] xhot The desired x-coordinate, in pixels, of the cursor hotspot.
+     *  @param[in] yhot The desired y-coordinate, in pixels, of the cursor hotspot.
+     *  @return The handle of the created cursor, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The specified image data is copied before this function
+     *  returns.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_object
+     *  @sa @ref glfwDestroyCursor
+     *  @sa @ref glfwCreateStandardCursor
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWcursor *glfwCreateCursor(const GLFWimage *image, int xhot, int yhot);
+
+    /*! @brief Creates a cursor with a standard shape.
+     *
+     *  Returns a cursor with a standard shape, that can be set for a window with
+     *  @ref glfwSetCursor.  The images for these cursors come from the system
+     *  cursor theme and their exact appearance will vary between platforms.
+     *
+     *  Most of these shapes are guaranteed to exist on every supported platform but
+     *  a few may not be present.  See the table below for details.
+     *
+     *  Cursor shape                   | Windows | macOS | X11    | Wayland
+     *  ------------------------------ | ------- | ----- | ------ | -------
+     *  @ref GLFW_ARROW_CURSOR         | Yes     | Yes   | Yes    | Yes
+     *  @ref GLFW_IBEAM_CURSOR         | Yes     | Yes   | Yes    | Yes
+     *  @ref GLFW_CROSSHAIR_CURSOR     | Yes     | Yes   | Yes    | Yes
+     *  @ref GLFW_POINTING_HAND_CURSOR | Yes     | Yes   | Yes    | Yes
+     *  @ref GLFW_RESIZE_EW_CURSOR     | Yes     | Yes   | Yes    | Yes
+     *  @ref GLFW_RESIZE_NS_CURSOR     | Yes     | Yes   | Yes    | Yes
+     *  @ref GLFW_RESIZE_NWSE_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
+     *  @ref GLFW_RESIZE_NESW_CURSOR   | Yes     | Yes<sup>1</sup> | Maybe<sup>2</sup> | Maybe<sup>2</sup>
+     *  @ref GLFW_RESIZE_ALL_CURSOR    | Yes     | Yes   | Yes    | Yes
+     *  @ref GLFW_NOT_ALLOWED_CURSOR   | Yes     | Yes   | Maybe<sup>2</sup> | Maybe<sup>2</sup>
+     *
+     *  1) This uses a private system API and may fail in the future.
+     *
+     *  2) This uses a newer standard that not all cursor themes support.
+     *
+     *  If the requested shape is not available, this function emits a @ref
+     *  GLFW_CURSOR_UNAVAILABLE error and returns `NULL`.
+     *
+     *  @param[in] shape One of the [standard shapes](@ref shapes).
+     *  @return A new cursor ready to use or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM, @ref GLFW_CURSOR_UNAVAILABLE and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_standard
+     *  @sa @ref glfwCreateCursor
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWcursor *glfwCreateStandardCursor(int shape);
+
+    /*! @brief Destroys a cursor.
+     *
+     *  This function destroys a cursor previously created with @ref
+     *  glfwCreateCursor.  Any remaining cursors will be destroyed by @ref
+     *  glfwTerminate.
+     *
+     *  If the specified cursor is current for any window, that window will be
+     *  reverted to the default cursor.  This does not affect the cursor mode.
+     *
+     *  @param[in] cursor The cursor object to destroy.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @reentrancy This function must not be called from a callback.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_object
+     *  @sa @ref glfwCreateCursor
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwDestroyCursor(GLFWcursor *cursor);
+
+    /*! @brief Sets the cursor for the window.
+     *
+     *  This function sets the cursor image to be used when the cursor is over the
+     *  content area of the specified window.  The set cursor will only be visible
+     *  when the [cursor mode](@ref cursor_mode) of the window is
+     *  `GLFW_CURSOR_NORMAL`.
+     *
+     *  On some platforms, the set cursor may not be visible unless the window also
+     *  has input focus.
+     *
+     *  @param[in] window The window to set the cursor for.
+     *  @param[in] cursor The cursor to set, or `NULL` to switch back to the default
+     *  arrow cursor.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_object
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwSetCursor(GLFWwindow *window, GLFWcursor *cursor);
+
+    /*! @brief Sets the key callback.
+     *
+     *  This function sets the key callback of the specified window, which is called
+     *  when a key is pressed, repeated or released.
+     *
+     *  The key functions deal with physical keys, with layout independent
+     *  [key tokens](@ref keys) named after their values in the standard US keyboard
+     *  layout.  If you want to input text, use the
+     *  [character callback](@ref glfwSetCharCallback) instead.
+     *
+     *  When a window loses input focus, it will generate synthetic key release
+     *  events for all pressed keys.  You can tell these events from user-generated
+     *  events by the fact that the synthetic ones are generated after the focus
+     *  loss event has been processed, i.e. after the
+     *  [window focus callback](@ref glfwSetWindowFocusCallback) has been called.
+     *
+     *  The scancode of a key is specific to that platform or sometimes even to that
+     *  machine.  Scancodes are intended to allow users to bind keys that don't have
+     *  a GLFW key token.  Such keys have `key` set to `GLFW_KEY_UNKNOWN`, their
+     *  state is not saved and so it cannot be queried with @ref glfwGetKey.
+     *
+     *  Sometimes GLFW needs to generate synthetic key events, in which case the
+     *  scancode may be zero.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new key callback, or `NULL` to remove the currently
+     *  set callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int key, int scancode, int action, int mods)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWkeyfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref input_key
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter and return value.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow *window, GLFWkeyfun callback);
+
+    /*! @brief Sets the Unicode character callback.
+     *
+     *  This function sets the character callback of the specified window, which is
+     *  called when a Unicode character is input.
+     *
+     *  The character callback is intended for Unicode text input.  As it deals with
+     *  characters, it is keyboard layout dependent, whereas the
+     *  [key callback](@ref glfwSetKeyCallback) is not.  Characters do not map 1:1
+     *  to physical keys, as a key may produce zero, one or more characters.  If you
+     *  want to know whether a specific physical key was pressed or released, see
+     *  the key callback instead.
+     *
+     *  The character callback behaves as system text input normally does and will
+     *  not be called if modifier keys are held down that would prevent normal text
+     *  input on that platform, for example a Super (Command) key on macOS or Alt key
+     *  on Windows.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, unsigned int codepoint)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWcharfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref input_char
+     *
+     *  @since Added in version 2.4.
+     *  @glfw3 Added window handle parameter and return value.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow *window, GLFWcharfun callback);
+
+    /*! @brief Sets the Unicode character with modifiers callback.
+     *
+     *  This function sets the character with modifiers callback of the specified
+     *  window, which is called when a Unicode character is input regardless of what
+     *  modifier keys are used.
+     *
+     *  The character with modifiers callback is intended for implementing custom
+     *  Unicode character input.  For regular Unicode text input, see the
+     *  [character callback](@ref glfwSetCharCallback).  Like the character
+     *  callback, the character with modifiers callback deals with characters and is
+     *  keyboard layout dependent.  Characters do not map 1:1 to physical keys, as
+     *  a key may produce zero, one or more characters.  If you want to know whether
+     *  a specific physical key was pressed or released, see the
+     *  [key callback](@ref glfwSetKeyCallback) instead.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, unsigned int codepoint, int mods)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWcharmodsfun).
+     *
+     *  @deprecated Scheduled for removal in version 4.0.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref input_char
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWcharmodsfun glfwSetCharModsCallback(GLFWwindow *window, GLFWcharmodsfun callback);
+
+    /*! @brief Sets the mouse button callback.
+     *
+     *  This function sets the mouse button callback of the specified window, which
+     *  is called when a mouse button is pressed or released.
+     *
+     *  When a window loses input focus, it will generate synthetic mouse button
+     *  release events for all pressed mouse buttons.  You can tell these events
+     *  from user-generated events by the fact that the synthetic ones are generated
+     *  after the focus loss event has been processed, i.e. after the
+     *  [window focus callback](@ref glfwSetWindowFocusCallback) has been called.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int button, int action, int mods)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWmousebuttonfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref input_mouse_button
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter and return value.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow *window, GLFWmousebuttonfun callback);
+
+    /*! @brief Sets the cursor position callback.
+     *
+     *  This function sets the cursor position callback of the specified window,
+     *  which is called when the cursor is moved.  The callback is provided with the
+     *  position, in screen coordinates, relative to the upper-left corner of the
+     *  content area of the window.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, double xpos, double ypos);
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWcursorposfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_pos
+     *
+     *  @since Added in version 3.0.  Replaces `glfwSetMousePosCallback`.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow *window, GLFWcursorposfun callback);
+
+    /*! @brief Sets the cursor enter/leave callback.
+     *
+     *  This function sets the cursor boundary crossing callback of the specified
+     *  window, which is called when the cursor enters or leaves the content area of
+     *  the window.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int entered)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWcursorenterfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref cursor_enter
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow *window, GLFWcursorenterfun callback);
+
+    /*! @brief Sets the scroll callback.
+     *
+     *  This function sets the scroll callback of the specified window, which is
+     *  called when a scrolling device is used, such as a mouse wheel or scrolling
+     *  area of a touchpad.
+     *
+     *  The scroll callback receives all scrolling input, like that from a mouse
+     *  wheel or a touchpad scrolling area.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new scroll callback, or `NULL` to remove the
+     *  currently set callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, double xoffset, double yoffset)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWscrollfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref scrolling
+     *
+     *  @since Added in version 3.0.  Replaces `glfwSetMouseWheelCallback`.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow *window, GLFWscrollfun callback);
+
+    /*! @brief Sets the path drop callback.
+     *
+     *  This function sets the path drop callback of the specified window, which is
+     *  called when one or more dragged paths are dropped on the window.
+     *
+     *  Because the path array and its strings may have been generated specifically
+     *  for that event, they are not guaranteed to be valid after the callback has
+     *  returned.  If you wish to use them after the callback returns, you need to
+     *  make a deep copy.
+     *
+     *  @param[in] window The window whose callback to set.
+     *  @param[in] callback The new file drop callback, or `NULL` to remove the
+     *  currently set callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(GLFWwindow* window, int path_count, const char* paths[])
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWdropfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @remark @wayland File drop is currently unimplemented.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref path_drop
+     *
+     *  @since Added in version 3.1.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWdropfun glfwSetDropCallback(GLFWwindow *window, GLFWdropfun callback);
+
+    /*! @brief Returns whether the specified joystick is present.
+     *
+     *  This function returns whether the specified joystick is present.
+     *
+     *  There is no need to call this function before other functions that accept
+     *  a joystick ID, as they all check for presence before performing any other
+     *  work.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @return `GLFW_TRUE` if the joystick is present, or `GLFW_FALSE` otherwise.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref joystick
+     *
+     *  @since Added in version 3.0.  Replaces `glfwGetJoystickParam`.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwJoystickPresent(int jid);
+
+    /*! @brief Returns the values of all axes of the specified joystick.
+     *
+     *  This function returns the values of all axes of the specified joystick.
+     *  Each element in the array is a value between -1.0 and 1.0.
+     *
+     *  If the specified joystick is not present this function will return `NULL`
+     *  but will not generate an error.  This can be used instead of first calling
+     *  @ref glfwJoystickPresent.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @param[out] count Where to store the number of axis values in the returned
+     *  array.  This is set to zero if the joystick is not present or an error
+     *  occurred.
+     *  @return An array of axis values, or `NULL` if the joystick is not present or
+     *  an [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified joystick is
+     *  disconnected or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref joystick_axis
+     *
+     *  @since Added in version 3.0.  Replaces `glfwGetJoystickPos`.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const float *glfwGetJoystickAxes(int jid, int *count);
+
+    /*! @brief Returns the state of all buttons of the specified joystick.
+     *
+     *  This function returns the state of all buttons of the specified joystick.
+     *  Each element in the array is either `GLFW_PRESS` or `GLFW_RELEASE`.
+     *
+     *  For backward compatibility with earlier versions that did not have @ref
+     *  glfwGetJoystickHats, the button array also includes all hats, each
+     *  represented as four buttons.  The hats are in the same order as returned by
+     *  __glfwGetJoystickHats__ and are in the order _up_, _right_, _down_ and
+     *  _left_.  To disable these extra buttons, set the @ref
+     *  GLFW_JOYSTICK_HAT_BUTTONS init hint before initialization.
+     *
+     *  If the specified joystick is not present this function will return `NULL`
+     *  but will not generate an error.  This can be used instead of first calling
+     *  @ref glfwJoystickPresent.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @param[out] count Where to store the number of button states in the returned
+     *  array.  This is set to zero if the joystick is not present or an error
+     *  occurred.
+     *  @return An array of button states, or `NULL` if the joystick is not present
+     *  or an [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified joystick is
+     *  disconnected or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref joystick_button
+     *
+     *  @since Added in version 2.2.
+     *  @glfw3 Changed to return a dynamic array.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const unsigned char *glfwGetJoystickButtons(int jid, int *count);
+
+    /*! @brief Returns the state of all hats of the specified joystick.
+     *
+     *  This function returns the state of all hats of the specified joystick.
+     *  Each element in the array is one of the following values:
+     *
+     *  Name                  | Value
+     *  ----                  | -----
+     *  `GLFW_HAT_CENTERED`   | 0
+     *  `GLFW_HAT_UP`         | 1
+     *  `GLFW_HAT_RIGHT`      | 2
+     *  `GLFW_HAT_DOWN`       | 4
+     *  `GLFW_HAT_LEFT`       | 8
+     *  `GLFW_HAT_RIGHT_UP`   | `GLFW_HAT_RIGHT` \| `GLFW_HAT_UP`
+     *  `GLFW_HAT_RIGHT_DOWN` | `GLFW_HAT_RIGHT` \| `GLFW_HAT_DOWN`
+     *  `GLFW_HAT_LEFT_UP`    | `GLFW_HAT_LEFT` \| `GLFW_HAT_UP`
+     *  `GLFW_HAT_LEFT_DOWN`  | `GLFW_HAT_LEFT` \| `GLFW_HAT_DOWN`
+     *
+     *  The diagonal directions are bitwise combinations of the primary (up, right,
+     *  down and left) directions and you can test for these individually by ANDing
+     *  it with the corresponding direction.
+     *
+     *  @code
+     *  if (hats[2] & GLFW_HAT_RIGHT)
+     *  {
+     *      // State of hat 2 could be right-up, right or right-down
+     *  }
+     *  @endcode
+     *
+     *  If the specified joystick is not present this function will return `NULL`
+     *  but will not generate an error.  This can be used instead of first calling
+     *  @ref glfwJoystickPresent.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @param[out] count Where to store the number of hat states in the returned
+     *  array.  This is set to zero if the joystick is not present or an error
+     *  occurred.
+     *  @return An array of hat states, or `NULL` if the joystick is not present
+     *  or an [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified joystick is
+     *  disconnected, this function is called again for that joystick or the library
+     *  is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref joystick_hat
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const unsigned char *glfwGetJoystickHats(int jid, int *count);
+
+    /*! @brief Returns the name of the specified joystick.
+     *
+     *  This function returns the name, encoded as UTF-8, of the specified joystick.
+     *  The returned string is allocated and freed by GLFW.  You should not free it
+     *  yourself.
+     *
+     *  If the specified joystick is not present this function will return `NULL`
+     *  but will not generate an error.  This can be used instead of first calling
+     *  @ref glfwJoystickPresent.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @return The UTF-8 encoded name of the joystick, or `NULL` if the joystick
+     *  is not present or an [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified joystick is
+     *  disconnected or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref joystick_name
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const char *glfwGetJoystickName(int jid);
+
+    /*! @brief Returns the SDL compatible GUID of the specified joystick.
+     *
+     *  This function returns the SDL compatible GUID, as a UTF-8 encoded
+     *  hexadecimal string, of the specified joystick.  The returned string is
+     *  allocated and freed by GLFW.  You should not free it yourself.
+     *
+     *  The GUID is what connects a joystick to a gamepad mapping.  A connected
+     *  joystick will always have a GUID even if there is no gamepad mapping
+     *  assigned to it.
+     *
+     *  If the specified joystick is not present this function will return `NULL`
+     *  but will not generate an error.  This can be used instead of first calling
+     *  @ref glfwJoystickPresent.
+     *
+     *  The GUID uses the format introduced in SDL 2.0.5.  This GUID tries to
+     *  uniquely identify the make and model of a joystick but does not identify
+     *  a specific unit, e.g. all wired Xbox 360 controllers will have the same
+     *  GUID on that platform.  The GUID for a unit may vary between platforms
+     *  depending on what hardware information the platform specific APIs provide.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @return The UTF-8 encoded GUID of the joystick, or `NULL` if the joystick
+     *  is not present or an [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_INVALID_ENUM and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified joystick is
+     *  disconnected or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref gamepad
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const char *glfwGetJoystickGUID(int jid);
+
+    /*! @brief Sets the user pointer of the specified joystick.
+     *
+     *  This function sets the user-defined pointer of the specified joystick.  The
+     *  current value is retained until the joystick is disconnected.  The initial
+     *  value is `NULL`.
+     *
+     *  This function may be called from the joystick callback, even for a joystick
+     *  that is being disconnected.
+     *
+     *  @param[in] jid The joystick whose pointer to set.
+     *  @param[in] pointer The new value.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref joystick_userptr
+     *  @sa @ref glfwGetJoystickUserPointer
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwSetJoystickUserPointer(int jid, void *pointer);
+
+    /*! @brief Returns the user pointer of the specified joystick.
+     *
+     *  This function returns the current value of the user-defined pointer of the
+     *  specified joystick.  The initial value is `NULL`.
+     *
+     *  This function may be called from the joystick callback, even for a joystick
+     *  that is being disconnected.
+     *
+     *  @param[in] jid The joystick whose pointer to return.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Access is not
+     *  synchronized.
+     *
+     *  @sa @ref joystick_userptr
+     *  @sa @ref glfwSetJoystickUserPointer
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void *glfwGetJoystickUserPointer(int jid);
+
+    /*! @brief Returns whether the specified joystick has a gamepad mapping.
+     *
+     *  This function returns whether the specified joystick is both present and has
+     *  a gamepad mapping.
+     *
+     *  If the specified joystick is present but does not have a gamepad mapping
+     *  this function will return `GLFW_FALSE` but will not generate an error.  Call
+     *  @ref glfwJoystickPresent to check if a joystick is present regardless of
+     *  whether it has a mapping.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @return `GLFW_TRUE` if a joystick is both present and has a gamepad mapping,
+     *  or `GLFW_FALSE` otherwise.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref gamepad
+     *  @sa @ref glfwGetGamepadState
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwJoystickIsGamepad(int jid);
+
+    /*! @brief Sets the joystick configuration callback.
+     *
+     *  This function sets the joystick configuration callback, or removes the
+     *  currently set callback.  This is called when a joystick is connected to or
+     *  disconnected from the system.
+     *
+     *  For joystick connection and disconnection events to be delivered on all
+     *  platforms, you need to call one of the [event processing](@ref events)
+     *  functions.  Joystick disconnection may also be detected and the callback
+     *  called by joystick functions.  The function will then return whatever it
+     *  returns if the joystick is not present.
+     *
+     *  @param[in] callback The new callback, or `NULL` to remove the currently set
+     *  callback.
+     *  @return The previously set callback, or `NULL` if no callback was set or the
+     *  library had not been [initialized](@ref intro_init).
+     *
+     *  @callback_signature
+     *  @code
+     *  void function_name(int jid, int event)
+     *  @endcode
+     *  For more information about the callback parameters, see the
+     *  [function pointer type](@ref GLFWjoystickfun).
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref joystick_event
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI GLFWjoystickfun glfwSetJoystickCallback(GLFWjoystickfun callback);
+
+    /*! @brief Adds the specified SDL_GameControllerDB gamepad mappings.
+     *
+     *  This function parses the specified ASCII encoded string and updates the
+     *  internal list with any gamepad mappings it finds.  This string may
+     *  contain either a single gamepad mapping or many mappings separated by
+     *  newlines.  The parser supports the full format of the `gamecontrollerdb.txt`
+     *  source file including empty lines and comments.
+     *
+     *  See @ref gamepad_mapping for a description of the format.
+     *
+     *  If there is already a gamepad mapping for a given GUID in the internal list,
+     *  it will be replaced by the one passed to this function.  If the library is
+     *  terminated and re-initialized the internal list will revert to the built-in
+     *  default.
+     *
+     *  @param[in] string The string containing the gamepad mappings.
+     *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_VALUE.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref gamepad
+     *  @sa @ref glfwJoystickIsGamepad
+     *  @sa @ref glfwGetGamepadName
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwUpdateGamepadMappings(const char *string);
+
+    /*! @brief Returns the human-readable gamepad name for the specified joystick.
+     *
+     *  This function returns the human-readable name of the gamepad from the
+     *  gamepad mapping assigned to the specified joystick.
+     *
+     *  If the specified joystick is not present or does not have a gamepad mapping
+     *  this function will return `NULL` but will not generate an error.  Call
+     *  @ref glfwJoystickPresent to check whether it is present regardless of
+     *  whether it has a mapping.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @return The UTF-8 encoded name of the gamepad, or `NULL` if the
+     *  joystick is not present, does not have a mapping or an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the specified joystick is
+     *  disconnected, the gamepad mappings are updated or the library is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref gamepad
+     *  @sa @ref glfwJoystickIsGamepad
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const char *glfwGetGamepadName(int jid);
+
+    /*! @brief Retrieves the state of the specified joystick remapped as a gamepad.
+     *
+     *  This function retrieves the state of the specified joystick remapped to
+     *  an Xbox-like gamepad.
+     *
+     *  If the specified joystick is not present or does not have a gamepad mapping
+     *  this function will return `GLFW_FALSE` but will not generate an error.  Call
+     *  @ref glfwJoystickPresent to check whether it is present regardless of
+     *  whether it has a mapping.
+     *
+     *  The Guide button may not be available for input as it is often hooked by the
+     *  system or the Steam client.
+     *
+     *  Not all devices have all the buttons or axes provided by @ref
+     *  GLFWgamepadstate.  Unavailable buttons and axes will always report
+     *  `GLFW_RELEASE` and 0.0 respectively.
+     *
+     *  @param[in] jid The [joystick](@ref joysticks) to query.
+     *  @param[out] state The gamepad input state of the joystick.
+     *  @return `GLFW_TRUE` if successful, or `GLFW_FALSE` if no joystick is
+     *  connected, it has no gamepad mapping or an [error](@ref error_handling)
+     *  occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_ENUM.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref gamepad
+     *  @sa @ref glfwUpdateGamepadMappings
+     *  @sa @ref glfwJoystickIsGamepad
+     *
+     *  @since Added in version 3.3.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI int glfwGetGamepadState(int jid, GLFWgamepadstate *state);
+
+    /*! @brief Sets the clipboard to the specified string.
+     *
+     *  This function sets the system clipboard to the specified, UTF-8 encoded
+     *  string.
+     *
+     *  @param[in] window Deprecated.  Any valid window or `NULL`.
+     *  @param[in] string A UTF-8 encoded string.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The specified string is copied before this function
+     *  returns.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref clipboard
+     *  @sa @ref glfwGetClipboardString
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwSetClipboardString(GLFWwindow *window, const char *string);
+
+    /*! @brief Returns the contents of the clipboard as a string.
+     *
+     *  This function returns the contents of the system clipboard, if it contains
+     *  or is convertible to a UTF-8 encoded string.  If the clipboard is empty or
+     *  if its contents cannot be converted, `NULL` is returned and a @ref
+     *  GLFW_FORMAT_UNAVAILABLE error is generated.
+     *
+     *  @param[in] window Deprecated.  Any valid window or `NULL`.
+     *  @return The contents of the clipboard as a UTF-8 encoded string, or `NULL`
+     *  if an [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @pointer_lifetime The returned string is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is valid until the next call to @ref
+     *  glfwGetClipboardString or @ref glfwSetClipboardString, or until the library
+     *  is terminated.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref clipboard
+     *  @sa @ref glfwSetClipboardString
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI const char *glfwGetClipboardString(GLFWwindow *window);
+
+    /*! @brief Returns the GLFW time.
+     *
+     *  This function returns the current GLFW time, in seconds.  Unless the time
+     *  has been set using @ref glfwSetTime it measures time elapsed since GLFW was
+     *  initialized.
+     *
+     *  This function and @ref glfwSetTime are helper functions on top of @ref
+     *  glfwGetTimerFrequency and @ref glfwGetTimerValue.
+     *
+     *  The resolution of the timer is system dependent, but is usually on the order
+     *  of a few micro- or nanoseconds.  It uses the highest-resolution monotonic
+     *  time source on each supported platform.
+     *
+     *  @return The current time, in seconds, or zero if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.  Reading and
+     *  writing of the internal base time is not atomic, so it needs to be
+     *  externally synchronized with calls to @ref glfwSetTime.
+     *
+     *  @sa @ref time
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI double glfwGetTime(void);
+
+    /*! @brief Sets the GLFW time.
+     *
+     *  This function sets the current GLFW time, in seconds.  The value must be
+     *  a positive finite number less than or equal to 18446744073.0, which is
+     *  approximately 584.5 years.
+     *
+     *  This function and @ref glfwGetTime are helper functions on top of @ref
+     *  glfwGetTimerFrequency and @ref glfwGetTimerValue.
+     *
+     *  @param[in] time The new value, in seconds.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_INVALID_VALUE.
+     *
+     *  @remark The upper limit of GLFW time is calculated as
+     *  floor((2<sup>64</sup> - 1) / 10<sup>9</sup>) and is due to implementations
+     *  storing nanoseconds in 64 bits.  The limit may be increased in the future.
+     *
+     *  @thread_safety This function may be called from any thread.  Reading and
+     *  writing of the internal base time is not atomic, so it needs to be
+     *  externally synchronized with calls to @ref glfwGetTime.
+     *
+     *  @sa @ref time
+     *
+     *  @since Added in version 2.2.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI void glfwSetTime(double time);
+
+    /*! @brief Returns the current value of the raw timer.
+     *
+     *  This function returns the current value of the raw timer, measured in
+     *  1&nbsp;/&nbsp;frequency seconds.  To get the frequency, call @ref
+     *  glfwGetTimerFrequency.
+     *
+     *  @return The value of the timer, or zero if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref time
+     *  @sa @ref glfwGetTimerFrequency
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI uint64_t glfwGetTimerValue(void);
+
+    /*! @brief Returns the frequency, in Hz, of the raw timer.
+     *
+     *  This function returns the frequency, in Hz, of the raw timer.
+     *
+     *  @return The frequency of the timer, in Hz, or zero if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref time
+     *  @sa @ref glfwGetTimerValue
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup input
+     */
+    GLFWAPI uint64_t glfwGetTimerFrequency(void);
+
+    /*! @brief Makes the context of the specified window current for the calling
+     *  thread.
+     *
+     *  This function makes the OpenGL or OpenGL ES context of the specified window
+     *  current on the calling thread.  A context must only be made current on
+     *  a single thread at a time and each thread can have only a single current
+     *  context at a time.
+     *
+     *  Making a context of a window current on a given thread will detach
+     *  any user context which is current on that thread and visa versa.
+     *
+     *  When moving a context between threads, you must make it non-current on the
+     *  old thread before making it current on the new one.
+     *
+     *  By default, making a context non-current implicitly forces a pipeline flush.
+     *  On machines that support `GL_KHR_context_flush_control`, you can control
+     *  whether a context performs this flush by setting the
+     *  [GLFW_CONTEXT_RELEASE_BEHAVIOR](@ref GLFW_CONTEXT_RELEASE_BEHAVIOR_hint)
+     *  hint.
+     *
+     *  The specified window must have an OpenGL or OpenGL ES context.  Specifying
+     *  a window without a context will generate a @ref GLFW_NO_WINDOW_CONTEXT
+     *  error.
+     *
+     *  @param[in] window The window whose context to make current, or `NULL` to
+     *  detach the current context.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_NO_WINDOW_CONTEXT and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref context_current
+     *  @sa @ref glfwGetCurrentContext
+     *  @sa @ref context_current_user
+     *  @sa @ref glfwMakeUserContextCurrent
+     *  @sa @ref glfwGetCurrentUserContext
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI void glfwMakeContextCurrent(GLFWwindow *window);
+
+    /*! @brief Returns the window whose context is current on the calling thread.
+     *
+     *  This function returns the window whose OpenGL or OpenGL ES context is
+     *  current on the calling thread.
+     *
+     *  @return The window whose context is current, or `NULL` if no window's
+     *  context is current.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref context_current
+     *  @sa @ref glfwMakeContextCurrent
+     *
+     *  @since Added in version 3.0.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI GLFWwindow *glfwGetCurrentContext(void);
+
+    /*! @brief Swaps the front and back buffers of the specified window.
+     *
+     *  This function swaps the front and back buffers of the specified window when
+     *  rendering with OpenGL or OpenGL ES.  If the swap interval is greater than
+     *  zero, the GPU driver waits the specified number of screen updates before
+     *  swapping the buffers.
+     *
+     *  The specified window must have an OpenGL or OpenGL ES context.  Specifying
+     *  a window without a context will generate a @ref GLFW_NO_WINDOW_CONTEXT
+     *  error.
+     *
+     *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+     *  see `vkQueuePresentKHR` instead.
+     *
+     *  @param[in] window The window whose buffers to swap.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_NO_WINDOW_CONTEXT and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark __EGL:__ The context of the specified window must be current on the
+     *  calling thread.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref buffer_swap
+     *  @sa @ref glfwSwapInterval
+     *
+     *  @since Added in version 1.0.
+     *  @glfw3 Added window handle parameter.
+     *
+     *  @ingroup window
+     */
+    GLFWAPI void glfwSwapBuffers(GLFWwindow *window);
+
+    /*! @brief Sets the swap interval for the current context.
+     *
+     *  This function sets the swap interval for the current OpenGL or OpenGL ES
+     *  context, i.e. the number of screen updates to wait from the time @ref
+     *  glfwSwapBuffers was called before swapping the buffers and returning.  This
+     *  is sometimes called _vertical synchronization_, _vertical retrace
+     *  synchronization_ or just _vsync_.
+     *
+     *  A context that supports either of the `WGL_EXT_swap_control_tear` and
+     *  `GLX_EXT_swap_control_tear` extensions also accepts _negative_ swap
+     *  intervals, which allows the driver to swap immediately even if a frame
+     *  arrives a little bit late.  You can check for these extensions with @ref
+     *  glfwExtensionSupported.
+     *
+     *  A context must be current on the calling thread.  Calling this function
+     *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
+     *
+     *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+     *  see the present mode of your swapchain instead.
+     *
+     *  @param[in] interval The minimum number of screen updates to wait for
+     *  until the buffers are swapped by @ref glfwSwapBuffers.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_NO_CURRENT_CONTEXT and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark This function is not called during context creation, leaving the
+     *  swap interval set to whatever is the default on that platform.  This is done
+     *  because some swap interval extensions used by GLFW do not allow the swap
+     *  interval to be reset to zero once it has been set to a non-zero value.
+     *
+     *  @remark Some GPU drivers do not honor the requested swap interval, either
+     *  because of a user setting that overrides the application's request or due to
+     *  bugs in the driver.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref buffer_swap
+     *  @sa @ref glfwSwapBuffers
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI void glfwSwapInterval(int interval);
+
+    /*! @brief Returns whether the specified extension is available.
+     *
+     *  This function returns whether the specified
+     *  [API extension](@ref context_glext) is supported by the current OpenGL or
+     *  OpenGL ES context.  It searches both for client API extension and context
+     *  creation API extensions.
+     *
+     *  A context must be current on the calling thread.  Calling this function
+     *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
+     *
+     *  As this functions retrieves and searches one or more extension strings each
+     *  call, it is recommended that you cache its results if it is going to be used
+     *  frequently.  The extension strings will not change during the lifetime of
+     *  a context, so there is no danger in doing this.
+     *
+     *  This function does not apply to Vulkan.  If you are using Vulkan, see @ref
+     *  glfwGetRequiredInstanceExtensions, `vkEnumerateInstanceExtensionProperties`
+     *  and `vkEnumerateDeviceExtensionProperties` instead.
+     *
+     *  @param[in] extension The ASCII encoded name of the extension.
+     *  @return `GLFW_TRUE` if the extension is available, or `GLFW_FALSE`
+     *  otherwise.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_NO_CURRENT_CONTEXT, @ref GLFW_INVALID_VALUE and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref context_glext
+     *  @sa @ref glfwGetProcAddress
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI int glfwExtensionSupported(const char *extension);
+
+    /*! @brief Returns the address of the specified function for the current
+     *  context.
+     *
+     *  This function returns the address of the specified OpenGL or OpenGL ES
+     *  [core or extension function](@ref context_glext), if it is supported
+     *  by the current context.
+     *
+     *  A context must be current on the calling thread.  Calling this function
+     *  without a current context will cause a @ref GLFW_NO_CURRENT_CONTEXT error.
+     *
+     *  This function does not apply to Vulkan.  If you are rendering with Vulkan,
+     *  see @ref glfwGetInstanceProcAddress, `vkGetInstanceProcAddr` and
+     *  `vkGetDeviceProcAddr` instead.
+     *
+     *  @param[in] procname The ASCII encoded name of the function.
+     *  @return The address of the function, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_NO_CURRENT_CONTEXT and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark The address of a given function is not guaranteed to be the same
+     *  between contexts.
+     *
+     *  @remark This function may return a non-`NULL` address despite the
+     *  associated version or extension not being available.  Always check the
+     *  context version or extension string first.
+     *
+     *  @pointer_lifetime The returned function pointer is valid until the context
+     *  is destroyed or the library is terminated.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref context_glext
+     *  @sa @ref glfwExtensionSupported
+     *
+     *  @since Added in version 1.0.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI GLFWglproc glfwGetProcAddress(const char *procname);
+
+    /*! @brief Create a new OpenGL or OpenGL ES user context for a window
+     *
+     *  This function creates a new OpenGL or OpenGL ES user context for a
+     *  window, which can be used to call OpenGL or OpenGL ES functions on
+     *  another thread. For a valid user context the window must be created
+     *  with a [GLFW_CLIENT_API](@ref GLFW_CLIENT_API_hint) other than
+     *  `GLFW_NO_API`.
+     *
+     *  User context creation uses the window context and framebuffer related
+     *  hints to ensure a valid context is created for that window, these hints
+     *  should be the same at the time of user context creation as when the
+     *  window was created.
+     *
+     *  Contexts share resources with the window context and with any other
+     *  user context created for that window.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED,
+     *  @ref GLFW_INVALID_VALUE the window parameter is `NULL`,
+     *  @ref GLFW_NO_WINDOW_CONTEXT if the window has no OpenGL or
+     *  OpenGL US context, and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @param[in] window The Window for which the user context is to be
+     *  created.
+     *  @return The handle of the user context created, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref context_user
+     *  @sa @ref usercontext_creation
+     *  @sa @ref glfwDestroyUserContext
+     *  @sa @ref window_creation
+     *  @sa @ref glfwCreateWindow
+     *  @sa @ref glfwDestroyWindow
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI GLFWusercontext *glfwCreateUserContext(GLFWwindow *window);
+
+    /*! @brief Destroys the specified user context
+     *
+     *  This function destroys the specified user context.
+     *  User contexts should be destroyed before destroying the
+     *  window they were made with.
+     *
+     *  If the user context is current on the main thread, it is
+     *  detached before being destroyed.
+     *
+     *  @param[in] context The user context to destroy.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_PLATFORM_ERROR.
+     *
+     *  @note The user context must not be current on any other
+     *  thread when this function is called.
+     *
+     *  @reentrancy This function must not be called from a callback.
+     *
+     *  @thread_safety This function must only be called from the main thread.
+     *
+     *  @sa @ref context_user
+     *  @sa @ref usercontext_creation
+     *  @sa @ref glfwCreateUserContext
+     *  @sa @ref window_creation
+     *  @sa @ref glfwCreateWindow
+     *  @sa @ref glfwDestroyWindow
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI void glfwDestroyUserContext(GLFWusercontext *context);
+
+    /*! @brief Makes the user context current for the calling thread.
+     *
+     *  This function makes the OpenGL or OpenGL ES context of the specified user
+     *  context current on the calling thread.  A context must only be made current on
+     *  a single thread at a time and each thread can have only a single current
+     *  context at a time.
+     *
+     *  Making a user context current on a given thread will detach the context of
+     *  any window which is current on that thread and visa versa.
+     *
+     *  When moving a context between threads, you must make it non-current on the
+     *  old thread before making it current on the new one.
+     *
+     *  By default, making a context non-current implicitly forces a pipeline flush.
+     *  On machines that support `GL_KHR_context_flush_control`, you can control
+     *  whether a context performs this flush by setting the
+     *  [GLFW_CONTEXT_RELEASE_BEHAVIOR](@ref GLFW_CONTEXT_RELEASE_BEHAVIOR_hint)
+     *  hint.
+     *
+     *  @param[in] context The user context to make current, or `NULL` to
+     *  detach the current context.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED,
+     *  and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref context_user
+     *  @sa @ref context_current_user
+     *  @sa @ref glfwGetCurrentUserContext
+     *  @sa @ref context_current
+     *  @sa @ref glfwMakeContextCurrent
+     *  @sa @ref glfwGetCurrentContext
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI void glfwMakeUserContextCurrent(GLFWusercontext *context);
+
+    /*! @brief Returns the current OpenGL or OpenGL ES user context
+     *
+     *  This function returns the user context which is current
+     *  on the calling thread.
+     *
+     *  @return The user context current, or `NULL` if no user context
+     *  is current.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref context_user
+     *  @sa @ref context_current_user
+     *  @sa @ref glfwMakeUserContextCurrent
+     *  @sa @ref context_current
+     *  @sa @ref glfwMakeContextCurrent
+     *  @sa @ref glfwGetCurrentContext
+     *
+     *  @since Added in version 3.4.
+     *
+     *  @ingroup context
+     */
+    GLFWAPI GLFWusercontext *glfwGetCurrentUserContext(void);
+
+    /*! @brief Returns whether the Vulkan loader and an ICD have been found.
+     *
+     *  This function returns whether the Vulkan loader and any minimally functional
+     *  ICD have been found.
+     *
+     *  The availability of a Vulkan loader and even an ICD does not by itself
+     *  guarantee that surface creation or even instance creation is possible.
+     *  For example, on Fermi systems Nvidia will install an ICD that provides no
+     *  actual Vulkan support.  Call @ref glfwGetRequiredInstanceExtensions to check
+     *  whether the extensions necessary for Vulkan surface creation are available
+     *  and @ref glfwGetPhysicalDevicePresentationSupport to check whether a queue
+     *  family of a physical device supports image presentation.
+     *
+     *  @return `GLFW_TRUE` if Vulkan is minimally available, or `GLFW_FALSE`
+     *  otherwise.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref vulkan_support
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup vulkan
+     */
+    GLFWAPI int glfwVulkanSupported(void);
+
+    /*! @brief Returns the Vulkan instance extensions required by GLFW.
+     *
+     *  This function returns an array of names of Vulkan instance extensions required
+     *  by GLFW for creating Vulkan surfaces for GLFW windows.  If successful, the
+     *  list will always contain `VK_KHR_surface`, so if you don't require any
+     *  additional extensions you can pass this list directly to the
+     *  `VkInstanceCreateInfo` struct.
+     *
+     *  If Vulkan is not available on the machine, this function returns `NULL` and
+     *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
+     *  to check whether Vulkan is at least minimally available.
+     *
+     *  If Vulkan is available but no set of extensions allowing window surface
+     *  creation was found, this function returns `NULL`.  You may still use Vulkan
+     *  for off-screen rendering and compute work.
+     *
+     *  @param[out] count Where to store the number of extensions in the returned
+     *  array.  This is set to zero if an error occurred.
+     *  @return An array of ASCII encoded extension names, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_API_UNAVAILABLE.
+     *
+     *  @remark Additional extensions may be required by future versions of GLFW.
+     *  You should check if any extensions you wish to enable are already in the
+     *  returned array, as it is an error to specify an extension more than once in
+     *  the `VkInstanceCreateInfo` struct.
+     *
+     *  @remark @macos GLFW currently supports both the `VK_MVK_macos_surface` and
+     *  the newer `VK_EXT_metal_surface` extensions.
+     *
+     *  @pointer_lifetime The returned array is allocated and freed by GLFW.  You
+     *  should not free it yourself.  It is guaranteed to be valid only until the
+     *  library is terminated.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref vulkan_ext
+     *  @sa @ref glfwCreateWindowSurface
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup vulkan
+     */
+    GLFWAPI const char **glfwGetRequiredInstanceExtensions(uint32_t *count);
 
 #if defined(VK_VERSION_1_0)
 
-/*! @brief Returns the address of the specified Vulkan instance function.
- *
- *  This function returns the address of the specified Vulkan core or extension
- *  function for the specified instance.  If instance is set to `NULL` it can
- *  return any function exported from the Vulkan loader, including at least the
- *  following functions:
- *
- *  - `vkEnumerateInstanceExtensionProperties`
- *  - `vkEnumerateInstanceLayerProperties`
- *  - `vkCreateInstance`
- *  - `vkGetInstanceProcAddr`
- *
- *  If Vulkan is not available on the machine, this function returns `NULL` and
- *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
- *  to check whether Vulkan is at least minimally available.
- *
- *  This function is equivalent to calling `vkGetInstanceProcAddr` with
- *  a platform-specific query of the Vulkan loader as a fallback.
- *
- *  @param[in] instance The Vulkan instance to query, or `NULL` to retrieve
- *  functions related to instance creation.
- *  @param[in] procname The ASCII encoded name of the function.
- *  @return The address of the function, or `NULL` if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
- *  GLFW_API_UNAVAILABLE.
- *
- *  @pointer_lifetime The returned function pointer is valid until the library
- *  is terminated.
- *
- *  @thread_safety This function may be called from any thread.
- *
- *  @sa @ref vulkan_proc
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup vulkan
- */
-GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance, const char* procname);
+    /*! @brief Returns the address of the specified Vulkan instance function.
+     *
+     *  This function returns the address of the specified Vulkan core or extension
+     *  function for the specified instance.  If instance is set to `NULL` it can
+     *  return any function exported from the Vulkan loader, including at least the
+     *  following functions:
+     *
+     *  - `vkEnumerateInstanceExtensionProperties`
+     *  - `vkEnumerateInstanceLayerProperties`
+     *  - `vkCreateInstance`
+     *  - `vkGetInstanceProcAddr`
+     *
+     *  If Vulkan is not available on the machine, this function returns `NULL` and
+     *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
+     *  to check whether Vulkan is at least minimally available.
+     *
+     *  This function is equivalent to calling `vkGetInstanceProcAddr` with
+     *  a platform-specific query of the Vulkan loader as a fallback.
+     *
+     *  @param[in] instance The Vulkan instance to query, or `NULL` to retrieve
+     *  functions related to instance creation.
+     *  @param[in] procname The ASCII encoded name of the function.
+     *  @return The address of the function, or `NULL` if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+     *  GLFW_API_UNAVAILABLE.
+     *
+     *  @pointer_lifetime The returned function pointer is valid until the library
+     *  is terminated.
+     *
+     *  @thread_safety This function may be called from any thread.
+     *
+     *  @sa @ref vulkan_proc
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup vulkan
+     */
+    GLFWAPI GLFWvkproc glfwGetInstanceProcAddress(VkInstance instance, const char *procname);
 
-/*! @brief Returns whether the specified queue family can present images.
- *
- *  This function returns whether the specified queue family of the specified
- *  physical device supports presentation to the platform GLFW was built for.
- *
- *  If Vulkan or the required window surface creation instance extensions are
- *  not available on the machine, or if the specified instance was not created
- *  with the required extensions, this function returns `GLFW_FALSE` and
- *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
- *  to check whether Vulkan is at least minimally available and @ref
- *  glfwGetRequiredInstanceExtensions to check what instance extensions are
- *  required.
- *
- *  @param[in] instance The instance that the physical device belongs to.
- *  @param[in] device The physical device that the queue family belongs to.
- *  @param[in] queuefamily The index of the queue family to query.
- *  @return `GLFW_TRUE` if the queue family supports presentation, or
- *  `GLFW_FALSE` otherwise.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_API_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
- *
- *  @remark @macos This function currently always returns `GLFW_TRUE`, as the
- *  `VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not provide
- *  a `vkGetPhysicalDevice*PresentationSupport` type function.
- *
- *  @thread_safety This function may be called from any thread.  For
- *  synchronization details of Vulkan objects, see the Vulkan specification.
- *
- *  @sa @ref vulkan_present
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup vulkan
- */
-GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
+    /*! @brief Returns whether the specified queue family can present images.
+     *
+     *  This function returns whether the specified queue family of the specified
+     *  physical device supports presentation to the platform GLFW was built for.
+     *
+     *  If Vulkan or the required window surface creation instance extensions are
+     *  not available on the machine, or if the specified instance was not created
+     *  with the required extensions, this function returns `GLFW_FALSE` and
+     *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported
+     *  to check whether Vulkan is at least minimally available and @ref
+     *  glfwGetRequiredInstanceExtensions to check what instance extensions are
+     *  required.
+     *
+     *  @param[in] instance The instance that the physical device belongs to.
+     *  @param[in] device The physical device that the queue family belongs to.
+     *  @param[in] queuefamily The index of the queue family to query.
+     *  @return `GLFW_TRUE` if the queue family supports presentation, or
+     *  `GLFW_FALSE` otherwise.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_API_UNAVAILABLE and @ref GLFW_PLATFORM_ERROR.
+     *
+     *  @remark @macos This function currently always returns `GLFW_TRUE`, as the
+     *  `VK_MVK_macos_surface` and `VK_EXT_metal_surface` extensions do not provide
+     *  a `vkGetPhysicalDevice*PresentationSupport` type function.
+     *
+     *  @thread_safety This function may be called from any thread.  For
+     *  synchronization details of Vulkan objects, see the Vulkan specification.
+     *
+     *  @sa @ref vulkan_present
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup vulkan
+     */
+    GLFWAPI int glfwGetPhysicalDevicePresentationSupport(VkInstance instance, VkPhysicalDevice device, uint32_t queuefamily);
 
-/*! @brief Creates a Vulkan surface for the specified window.
- *
- *  This function creates a Vulkan surface for the specified window.
- *
- *  If the Vulkan loader or at least one minimally functional ICD were not found,
- *  this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a @ref
- *  GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported to check whether
- *  Vulkan is at least minimally available.
- *
- *  If the required window surface creation instance extensions are not
- *  available or if the specified instance was not created with these extensions
- *  enabled, this function returns `VK_ERROR_EXTENSION_NOT_PRESENT` and
- *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref
- *  glfwGetRequiredInstanceExtensions to check what instance extensions are
- *  required.
- *
- *  The window surface cannot be shared with another API so the window must
- *  have been created with the [client api hint](@ref GLFW_CLIENT_API_attrib)
- *  set to `GLFW_NO_API` otherwise it generates a @ref GLFW_INVALID_VALUE error
- *  and returns `VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`.
- *
- *  The window surface must be destroyed before the specified Vulkan instance.
- *  It is the responsibility of the caller to destroy the window surface.  GLFW
- *  does not destroy it for you.  Call `vkDestroySurfaceKHR` to destroy the
- *  surface.
- *
- *  @param[in] instance The Vulkan instance to create the surface in.
- *  @param[in] window The window to create the surface for.
- *  @param[in] allocator The allocator to use, or `NULL` to use the default
- *  allocator.
- *  @param[out] surface Where to store the handle of the surface.  This is set
- *  to `VK_NULL_HANDLE` if an error occurred.
- *  @return `VK_SUCCESS` if successful, or a Vulkan error code if an
- *  [error](@ref error_handling) occurred.
- *
- *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
- *  GLFW_API_UNAVAILABLE, @ref GLFW_PLATFORM_ERROR and @ref GLFW_INVALID_VALUE
- *
- *  @remark If an error occurs before the creation call is made, GLFW returns
- *  the Vulkan error code most appropriate for the error.  Appropriate use of
- *  @ref glfwVulkanSupported and @ref glfwGetRequiredInstanceExtensions should
- *  eliminate almost all occurrences of these errors.
- *
- *  @remark @macos This function currently only supports the
- *  `VK_MVK_macos_surface` extension from MoltenVK.
- *
- *  @remark @macos This function creates and sets a `CAMetalLayer` instance for
- *  the window content view, which is required for MoltenVK to function.
- *
- *  @remark @x11 GLFW by default attempts to use the `VK_KHR_xcb_surface`
- *  extension, if available.  You can make it prefer the `VK_KHR_xlib_surface`
- *  extension by setting the
- *  [GLFW_X11_XCB_VULKAN_SURFACE](@ref GLFW_X11_XCB_VULKAN_SURFACE_hint) init
- *  hint.
- *
- *  @thread_safety This function may be called from any thread.  For
- *  synchronization details of Vulkan objects, see the Vulkan specification.
- *
- *  @sa @ref vulkan_surface
- *  @sa @ref glfwGetRequiredInstanceExtensions
- *
- *  @since Added in version 3.2.
- *
- *  @ingroup vulkan
- */
-GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface);
+    /*! @brief Creates a Vulkan surface for the specified window.
+     *
+     *  This function creates a Vulkan surface for the specified window.
+     *
+     *  If the Vulkan loader or at least one minimally functional ICD were not found,
+     *  this function returns `VK_ERROR_INITIALIZATION_FAILED` and generates a @ref
+     *  GLFW_API_UNAVAILABLE error.  Call @ref glfwVulkanSupported to check whether
+     *  Vulkan is at least minimally available.
+     *
+     *  If the required window surface creation instance extensions are not
+     *  available or if the specified instance was not created with these extensions
+     *  enabled, this function returns `VK_ERROR_EXTENSION_NOT_PRESENT` and
+     *  generates a @ref GLFW_API_UNAVAILABLE error.  Call @ref
+     *  glfwGetRequiredInstanceExtensions to check what instance extensions are
+     *  required.
+     *
+     *  The window surface cannot be shared with another API so the window must
+     *  have been created with the [client api hint](@ref GLFW_CLIENT_API_attrib)
+     *  set to `GLFW_NO_API` otherwise it generates a @ref GLFW_INVALID_VALUE error
+     *  and returns `VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`.
+     *
+     *  The window surface must be destroyed before the specified Vulkan instance.
+     *  It is the responsibility of the caller to destroy the window surface.  GLFW
+     *  does not destroy it for you.  Call `vkDestroySurfaceKHR` to destroy the
+     *  surface.
+     *
+     *  @param[in] instance The Vulkan instance to create the surface in.
+     *  @param[in] window The window to create the surface for.
+     *  @param[in] allocator The allocator to use, or `NULL` to use the default
+     *  allocator.
+     *  @param[out] surface Where to store the handle of the surface.  This is set
+     *  to `VK_NULL_HANDLE` if an error occurred.
+     *  @return `VK_SUCCESS` if successful, or a Vulkan error code if an
+     *  [error](@ref error_handling) occurred.
+     *
+     *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED, @ref
+     *  GLFW_API_UNAVAILABLE, @ref GLFW_PLATFORM_ERROR and @ref GLFW_INVALID_VALUE
+     *
+     *  @remark If an error occurs before the creation call is made, GLFW returns
+     *  the Vulkan error code most appropriate for the error.  Appropriate use of
+     *  @ref glfwVulkanSupported and @ref glfwGetRequiredInstanceExtensions should
+     *  eliminate almost all occurrences of these errors.
+     *
+     *  @remark @macos This function currently only supports the
+     *  `VK_MVK_macos_surface` extension from MoltenVK.
+     *
+     *  @remark @macos This function creates and sets a `CAMetalLayer` instance for
+     *  the window content view, which is required for MoltenVK to function.
+     *
+     *  @remark @x11 GLFW by default attempts to use the `VK_KHR_xcb_surface`
+     *  extension, if available.  You can make it prefer the `VK_KHR_xlib_surface`
+     *  extension by setting the
+     *  [GLFW_X11_XCB_VULKAN_SURFACE](@ref GLFW_X11_XCB_VULKAN_SURFACE_hint) init
+     *  hint.
+     *
+     *  @thread_safety This function may be called from any thread.  For
+     *  synchronization details of Vulkan objects, see the Vulkan specification.
+     *
+     *  @sa @ref vulkan_surface
+     *  @sa @ref glfwGetRequiredInstanceExtensions
+     *
+     *  @since Added in version 3.2.
+     *
+     *  @ingroup vulkan
+     */
+    GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow *window, const VkAllocationCallbacks *allocator, VkSurfaceKHR *surface);
 
 #endif /*VK_VERSION_1_0*/
 
+    /*************************************************************************
+     * Global definition cleanup
+     *************************************************************************/
 
-/*************************************************************************
- * Global definition cleanup
- *************************************************************************/
-
-/* ------------------- BEGIN SYSTEM/COMPILER SPECIFIC -------------------- */
+    /* ------------------- BEGIN SYSTEM/COMPILER SPECIFIC -------------------- */
 
 #ifdef GLFW_WINGDIAPI_DEFINED
- #undef WINGDIAPI
- #undef GLFW_WINGDIAPI_DEFINED
+#undef WINGDIAPI
+#undef GLFW_WINGDIAPI_DEFINED
 #endif
 
 #ifdef GLFW_CALLBACK_DEFINED
- #undef CALLBACK
- #undef GLFW_CALLBACK_DEFINED
+#undef CALLBACK
+#undef GLFW_CALLBACK_DEFINED
 #endif
 
 /* Some OpenGL related headers need GLAPIENTRY, but it is unconditionally
  * defined by some gl.h variants (OpenBSD) so define it after if needed.
  */
 #ifndef GLAPIENTRY
- #define GLAPIENTRY APIENTRY
+#define GLAPIENTRY APIENTRY
 #endif
 
-/* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
-
+    /* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* _glfw3_h_ */
-

--- a/src/internal.h
+++ b/src/internal.h
@@ -28,63 +28,63 @@
 #pragma once
 
 #if defined(_GLFW_USE_CONFIG_H)
- #include "glfw_config.h"
+#include "glfw_config.h"
 #endif
 
 #if defined(GLFW_INCLUDE_GLCOREARB) || \
-    defined(GLFW_INCLUDE_ES1)       || \
-    defined(GLFW_INCLUDE_ES2)       || \
-    defined(GLFW_INCLUDE_ES3)       || \
-    defined(GLFW_INCLUDE_ES31)      || \
-    defined(GLFW_INCLUDE_ES32)      || \
-    defined(GLFW_INCLUDE_NONE)      || \
-    defined(GLFW_INCLUDE_GLEXT)     || \
-    defined(GLFW_INCLUDE_GLU)       || \
-    defined(GLFW_INCLUDE_VULKAN)    || \
+    defined(GLFW_INCLUDE_ES1) ||       \
+    defined(GLFW_INCLUDE_ES2) ||       \
+    defined(GLFW_INCLUDE_ES3) ||       \
+    defined(GLFW_INCLUDE_ES31) ||      \
+    defined(GLFW_INCLUDE_ES32) ||      \
+    defined(GLFW_INCLUDE_NONE) ||      \
+    defined(GLFW_INCLUDE_GLEXT) ||     \
+    defined(GLFW_INCLUDE_GLU) ||       \
+    defined(GLFW_INCLUDE_VULKAN) ||    \
     defined(GLFW_DLL)
- #error "You must not define any header option macros when compiling GLFW"
+#error "You must not define any header option macros when compiling GLFW"
 #endif
 
 #define GLFW_INCLUDE_NONE
 #include "../include/GLFW/glfw3.h"
 
-#define _GLFW_INSERT_FIRST      0
-#define _GLFW_INSERT_LAST       1
+#define _GLFW_INSERT_FIRST 0
+#define _GLFW_INSERT_LAST 1
 
-#define _GLFW_POLL_PRESENCE     0
-#define _GLFW_POLL_AXES         1
-#define _GLFW_POLL_BUTTONS      2
-#define _GLFW_POLL_ALL          (_GLFW_POLL_AXES | _GLFW_POLL_BUTTONS)
+#define _GLFW_POLL_PRESENCE 0
+#define _GLFW_POLL_AXES 1
+#define _GLFW_POLL_BUTTONS 2
+#define _GLFW_POLL_ALL (_GLFW_POLL_AXES | _GLFW_POLL_BUTTONS)
 
-#define _GLFW_MESSAGE_SIZE      1024
+#define _GLFW_MESSAGE_SIZE 1024
 
 typedef int GLFWbool;
 
-typedef struct _GLFWerror       _GLFWerror;
-typedef struct _GLFWinitconfig  _GLFWinitconfig;
-typedef struct _GLFWwndconfig   _GLFWwndconfig;
-typedef struct _GLFWctxconfig   _GLFWctxconfig;
-typedef struct _GLFWfbconfig    _GLFWfbconfig;
-typedef struct _GLFWcontext     _GLFWcontext;
-typedef struct _GLFWwindow      _GLFWwindow;
-typedef struct _GLFWlibrary     _GLFWlibrary;
-typedef struct _GLFWmonitor     _GLFWmonitor;
-typedef struct _GLFWcursor      _GLFWcursor;
-typedef struct _GLFWmapelement  _GLFWmapelement;
-typedef struct _GLFWmapping     _GLFWmapping;
-typedef struct _GLFWjoystick    _GLFWjoystick;
-typedef struct _GLFWtls         _GLFWtls;
-typedef struct _GLFWmutex       _GLFWmutex;
+typedef struct _GLFWerror _GLFWerror;
+typedef struct _GLFWinitconfig _GLFWinitconfig;
+typedef struct _GLFWwndconfig _GLFWwndconfig;
+typedef struct _GLFWctxconfig _GLFWctxconfig;
+typedef struct _GLFWfbconfig _GLFWfbconfig;
+typedef struct _GLFWcontext _GLFWcontext;
+typedef struct _GLFWwindow _GLFWwindow;
+typedef struct _GLFWlibrary _GLFWlibrary;
+typedef struct _GLFWmonitor _GLFWmonitor;
+typedef struct _GLFWcursor _GLFWcursor;
+typedef struct _GLFWmapelement _GLFWmapelement;
+typedef struct _GLFWmapping _GLFWmapping;
+typedef struct _GLFWjoystick _GLFWjoystick;
+typedef struct _GLFWtls _GLFWtls;
+typedef struct _GLFWmutex _GLFWmutex;
 typedef struct _GLFWusercontext _GLFWusercontext;
 
-typedef void (* _GLFWmakecontextcurrentfun)(_GLFWwindow*);
-typedef void (* _GLFWswapbuffersfun)(_GLFWwindow*);
-typedef void (* _GLFWswapintervalfun)(int);
-typedef int (* _GLFWextensionsupportedfun)(const char*);
-typedef GLFWglproc (* _GLFWgetprocaddressfun)(const char*);
-typedef void (* _GLFWdestroycontextfun)(_GLFWwindow*);
-typedef void (* _GLFWmakeusercontextcurrentfun)(_GLFWusercontext* context);
-typedef void (* _GLFWdestroyusercontextfun)(_GLFWusercontext* context);
+typedef void (*_GLFWmakecontextcurrentfun)(_GLFWwindow *);
+typedef void (*_GLFWswapbuffersfun)(_GLFWwindow *);
+typedef void (*_GLFWswapintervalfun)(int);
+typedef int (*_GLFWextensionsupportedfun)(const char *);
+typedef GLFWglproc (*_GLFWgetprocaddressfun)(const char *);
+typedef void (*_GLFWdestroycontextfun)(_GLFWwindow *);
+typedef void (*_GLFWmakeusercontextcurrentfun)(_GLFWusercontext *context);
+typedef void (*_GLFWdestroyusercontextfun)(_GLFWusercontext *context);
 
 #define GL_VERSION 0x1f02
 #define GL_NONE 0
@@ -111,15 +111,15 @@ typedef unsigned int GLenum;
 typedef unsigned int GLbitfield;
 typedef unsigned char GLubyte;
 
-typedef void (APIENTRY * PFNGLCLEARPROC)(GLbitfield);
-typedef const GLubyte* (APIENTRY * PFNGLGETSTRINGPROC)(GLenum);
-typedef void (APIENTRY * PFNGLGETINTEGERVPROC)(GLenum,GLint*);
-typedef const GLubyte* (APIENTRY * PFNGLGETSTRINGIPROC)(GLenum,GLuint);
+typedef void(APIENTRY *PFNGLCLEARPROC)(GLbitfield);
+typedef const GLubyte *(APIENTRY *PFNGLGETSTRINGPROC)(GLenum);
+typedef void(APIENTRY *PFNGLGETINTEGERVPROC)(GLenum, GLint *);
+typedef const GLubyte *(APIENTRY *PFNGLGETSTRINGIPROC)(GLenum, GLuint);
 
 #define VK_NULL_HANDLE 0
 
-typedef void* VkInstance;
-typedef void* VkPhysicalDevice;
+typedef void *VkInstance;
+typedef void *VkPhysicalDevice;
 typedef uint64_t VkSurfaceKHR;
 typedef uint32_t VkFlags;
 typedef uint32_t VkBool32;
@@ -167,34 +167,34 @@ typedef struct VkAllocationCallbacks VkAllocationCallbacks;
 
 typedef struct VkExtensionProperties
 {
-    char            extensionName[256];
-    uint32_t        specVersion;
+    char extensionName[256];
+    uint32_t specVersion;
 } VkExtensionProperties;
 
-typedef void (APIENTRY * PFN_vkVoidFunction)(void);
+typedef void(APIENTRY *PFN_vkVoidFunction)(void);
 
 #if defined(_GLFW_VULKAN_STATIC)
-  PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance,const char*);
-  VkResult vkEnumerateInstanceExtensionProperties(const char*,uint32_t*,VkExtensionProperties*);
+PFN_vkVoidFunction vkGetInstanceProcAddr(VkInstance, const char *);
+VkResult vkEnumerateInstanceExtensionProperties(const char *, uint32_t *, VkExtensionProperties *);
 #else
-  typedef PFN_vkVoidFunction (APIENTRY * PFN_vkGetInstanceProcAddr)(VkInstance,const char*);
-  typedef VkResult (APIENTRY * PFN_vkEnumerateInstanceExtensionProperties)(const char*,uint32_t*,VkExtensionProperties*);
-  #define vkEnumerateInstanceExtensionProperties _glfw.vk.EnumerateInstanceExtensionProperties
-  #define vkGetInstanceProcAddr _glfw.vk.GetInstanceProcAddr
+typedef PFN_vkVoidFunction(APIENTRY *PFN_vkGetInstanceProcAddr)(VkInstance, const char *);
+typedef VkResult(APIENTRY *PFN_vkEnumerateInstanceExtensionProperties)(const char *, uint32_t *, VkExtensionProperties *);
+#define vkEnumerateInstanceExtensionProperties _glfw.vk.EnumerateInstanceExtensionProperties
+#define vkGetInstanceProcAddr _glfw.vk.GetInstanceProcAddr
 #endif
 
 #if defined(_GLFW_COCOA)
- #include "cocoa_platform.h"
+#include "cocoa_platform.h"
 #elif defined(_GLFW_WIN32)
- #include "win32_platform.h"
+#include "win32_platform.h"
 #elif defined(_GLFW_X11)
- #include "x11_platform.h"
+#include "x11_platform.h"
 #elif defined(_GLFW_WAYLAND)
- #include "wl_platform.h"
+#include "wl_platform.h"
 #elif defined(_GLFW_OSMESA)
- #include "null_platform.h"
+#include "null_platform.h"
 #else
- #error "No supported window creation API selected"
+#error "No supported window creation API selected"
 #endif
 
 #include "egl_context.h"
@@ -224,7 +224,7 @@ typedef void (APIENTRY * PFN_vkVoidFunction)(void);
 // Swaps the provided pointers
 #define _GLFW_SWAP_POINTERS(x, y) \
     {                             \
-        void* t;                  \
+        void *t;                  \
         t = x;                    \
         x = y;                    \
         y = t;                    \
@@ -234,9 +234,9 @@ typedef void (APIENTRY * PFN_vkVoidFunction)(void);
 //
 struct _GLFWerror
 {
-    _GLFWerror*     next;
-    int             code;
-    char            description[_GLFW_MESSAGE_SIZE];
+    _GLFWerror *next;
+    int code;
+    char description[_GLFW_MESSAGE_SIZE];
 };
 
 // Initialization configuration
@@ -245,14 +245,16 @@ struct _GLFWerror
 //
 struct _GLFWinitconfig
 {
-    GLFWbool      hatButtons;
-    int           angleType;
-    struct {
-        GLFWbool  menubar;
-        GLFWbool  chdir;
+    GLFWbool hatButtons;
+    int angleType;
+    struct
+    {
+        GLFWbool menubar;
+        GLFWbool chdir;
     } ns;
-    struct {
-        GLFWbool  xcbVulkanSurface;
+    struct
+    {
+        GLFWbool xcbVulkanSurface;
     } x11;
 };
 
@@ -264,31 +266,39 @@ struct _GLFWinitconfig
 //
 struct _GLFWwndconfig
 {
-    int           width;
-    int           height;
-    const char*   title;
-    void*         nativeParent;
-    GLFWbool      resizable;
-    GLFWbool      visible;
-    GLFWbool      decorated;
-    GLFWbool      focused;
-    GLFWbool      autoIconify;
-    GLFWbool      floating;
-    GLFWbool      maximized;
-    GLFWbool      centerCursor;
-    GLFWbool      focusOnShow;
-    GLFWbool      mousePassthrough;
-    GLFWbool      scaleToMonitor;
-    struct {
-        GLFWbool  retina;
-        char      frameName[256];
+    int width;
+    int height;
+    const char *title;
+    void *nativeParent;
+    GLFWbool resizable;
+    GLFWbool visible;
+    GLFWbool decorated;
+    GLFWbool focused;
+    GLFWbool autoIconify;
+    GLFWbool floating;
+    GLFWbool maximized;
+    GLFWbool centerCursor;
+    GLFWbool focusOnShow;
+    GLFWbool mousePassthrough;
+    GLFWbool scaleToMonitor;
+    GLFWbool isDesktopWindow;
+    GLFWbool sticky;
+    GLFWbool below;
+    GLFWbool skipTaskbar;
+    GLFWbool skipPager;
+    struct
+    {
+        GLFWbool retina;
+        char frameName[256];
     } ns;
-    struct {
-        char      className[256];
-        char      instanceName[256];
+    struct
+    {
+        char className[256];
+        char instanceName[256];
     } x11;
-    struct {
-        GLFWbool  keymenu;
+    struct
+    {
+        GLFWbool keymenu;
     } win32;
 };
 
@@ -300,19 +310,20 @@ struct _GLFWwndconfig
 //
 struct _GLFWctxconfig
 {
-    int           client;
-    int           source;
-    int           major;
-    int           minor;
-    GLFWbool      forward;
-    GLFWbool      debug;
-    GLFWbool      noerror;
-    int           profile;
-    int           robustness;
-    int           release;
-    _GLFWwindow*  share;
-    struct {
-        GLFWbool  offline;
+    int client;
+    int source;
+    int major;
+    int minor;
+    GLFWbool forward;
+    GLFWbool debug;
+    GLFWbool noerror;
+    int profile;
+    int robustness;
+    int release;
+    _GLFWwindow *share;
+    struct
+    {
+        GLFWbool offline;
     } nsgl;
 };
 
@@ -326,47 +337,47 @@ struct _GLFWctxconfig
 //
 struct _GLFWfbconfig
 {
-    int         redBits;
-    int         greenBits;
-    int         blueBits;
-    int         alphaBits;
-    int         depthBits;
-    int         stencilBits;
-    int         accumRedBits;
-    int         accumGreenBits;
-    int         accumBlueBits;
-    int         accumAlphaBits;
-    int         auxBuffers;
-    GLFWbool    stereo;
-    int         samples;
-    GLFWbool    sRGB;
-    GLFWbool    doublebuffer;
-    GLFWbool    transparent;
-    uintptr_t   handle;
+    int redBits;
+    int greenBits;
+    int blueBits;
+    int alphaBits;
+    int depthBits;
+    int stencilBits;
+    int accumRedBits;
+    int accumGreenBits;
+    int accumBlueBits;
+    int accumAlphaBits;
+    int auxBuffers;
+    GLFWbool stereo;
+    int samples;
+    GLFWbool sRGB;
+    GLFWbool doublebuffer;
+    GLFWbool transparent;
+    uintptr_t handle;
 };
 
 // Context structure
 //
 struct _GLFWcontext
 {
-    int                 client;
-    int                 source;
-    int                 major, minor, revision;
-    GLFWbool            forward, debug, noerror;
-    int                 profile;
-    int                 robustness;
-    int                 release;
+    int client;
+    int source;
+    int major, minor, revision;
+    GLFWbool forward, debug, noerror;
+    int profile;
+    int robustness;
+    int release;
 
-    PFNGLGETSTRINGIPROC  GetStringi;
+    PFNGLGETSTRINGIPROC GetStringi;
     PFNGLGETINTEGERVPROC GetIntegerv;
-    PFNGLGETSTRINGPROC   GetString;
+    PFNGLGETSTRINGPROC GetString;
 
-    _GLFWmakecontextcurrentfun  makeCurrent;
-    _GLFWswapbuffersfun         swapBuffers;
-    _GLFWswapintervalfun        swapInterval;
-    _GLFWextensionsupportedfun  extensionSupported;
-    _GLFWgetprocaddressfun      getProcAddress;
-    _GLFWdestroycontextfun      destroy;
+    _GLFWmakecontextcurrentfun makeCurrent;
+    _GLFWswapbuffersfun swapBuffers;
+    _GLFWswapintervalfun swapInterval;
+    _GLFWextensionsupportedfun extensionSupported;
+    _GLFWgetprocaddressfun getProcAddress;
+    _GLFWdestroycontextfun destroy;
 
     // This is defined in the context API's context.h
     _GLFW_PLATFORM_CONTEXT_STATE;
@@ -376,12 +387,11 @@ struct _GLFWcontext
     _GLFWcontextOSMesa osmesa;
 };
 
-
 // User Context structure
 //
 struct _GLFWusercontext
 {
-    _GLFWwindow* window;
+    _GLFWwindow *window;
 
     // This is defined in the context API's context.h
     _GLFW_PLATFORM_USER_CONTEXT_STATE;
@@ -398,56 +408,57 @@ struct _GLFWusercontext
 //
 struct _GLFWwindow
 {
-    struct _GLFWwindow* next;
+    struct _GLFWwindow *next;
 
     // Window settings and state
-    GLFWbool            resizable;
-    GLFWbool            decorated;
-    GLFWbool            autoIconify;
-    GLFWbool            floating;
-    GLFWbool            focusOnShow;
-    GLFWbool            mousePassthrough;
-    GLFWbool            shouldClose;
-    void*               userPointer;
-    GLFWbool            doublebuffer;
-    GLFWvidmode         videoMode;
-    _GLFWmonitor*       monitor;
-    _GLFWcursor*        cursor;
+    GLFWbool resizable;
+    GLFWbool decorated;
+    GLFWbool autoIconify;
+    GLFWbool floating;
+    GLFWbool focusOnShow;
+    GLFWbool mousePassthrough;
+    GLFWbool shouldClose;
+    void *userPointer;
+    GLFWbool doublebuffer;
+    GLFWvidmode videoMode;
+    _GLFWmonitor *monitor;
+    _GLFWcursor *cursor;
 
-    int                 minwidth, minheight;
-    int                 maxwidth, maxheight;
-    int                 numer, denom;
+    int minwidth, minheight;
+    int maxwidth, maxheight;
+    int numer, denom;
 
-    GLFWbool            stickyKeys;
-    GLFWbool            stickyMouseButtons;
-    GLFWbool            lockKeyMods;
-    int                 cursorMode;
-    char                mouseButtons[GLFW_MOUSE_BUTTON_LAST + 1];
-    char                keys[GLFW_KEY_LAST + 1];
+    GLFWbool stickyKeys;
+    GLFWbool stickyMouseButtons;
+    GLFWbool lockKeyMods;
+    int cursorMode;
+    char mouseButtons[GLFW_MOUSE_BUTTON_LAST + 1];
+    char keys[GLFW_KEY_LAST + 1];
     // Virtual cursor position when cursor is disabled
-    double              virtualCursorPosX, virtualCursorPosY;
-    GLFWbool            rawMouseMotion;
+    double virtualCursorPosX, virtualCursorPosY;
+    GLFWbool rawMouseMotion;
 
-    _GLFWcontext        context;
+    _GLFWcontext context;
 
-    struct {
-        GLFWwindowposfun          pos;
-        GLFWwindowsizefun         size;
-        GLFWwindowclosefun        close;
-        GLFWwindowrefreshfun      refresh;
-        GLFWwindowfocusfun        focus;
-        GLFWwindowiconifyfun      iconify;
-        GLFWwindowmaximizefun     maximize;
-        GLFWframebuffersizefun    fbsize;
+    struct
+    {
+        GLFWwindowposfun pos;
+        GLFWwindowsizefun size;
+        GLFWwindowclosefun close;
+        GLFWwindowrefreshfun refresh;
+        GLFWwindowfocusfun focus;
+        GLFWwindowiconifyfun iconify;
+        GLFWwindowmaximizefun maximize;
+        GLFWframebuffersizefun fbsize;
         GLFWwindowcontentscalefun scale;
-        GLFWmousebuttonfun        mouseButton;
-        GLFWcursorposfun          cursorPos;
-        GLFWcursorenterfun        cursorEnter;
-        GLFWscrollfun             scroll;
-        GLFWkeyfun                key;
-        GLFWcharfun               character;
-        GLFWcharmodsfun           charmods;
-        GLFWdropfun               drop;
+        GLFWmousebuttonfun mouseButton;
+        GLFWcursorposfun cursorPos;
+        GLFWcursorenterfun cursorEnter;
+        GLFWscrollfun scroll;
+        GLFWkeyfun key;
+        GLFWcharfun character;
+        GLFWcharmodsfun charmods;
+        GLFWdropfun drop;
     } callbacks;
 
     // This is defined in the window API's platform.h
@@ -458,21 +469,21 @@ struct _GLFWwindow
 //
 struct _GLFWmonitor
 {
-    char            name[128];
-    void*           userPointer;
+    char name[128];
+    void *userPointer;
 
     // Physical dimensions in millimeters.
-    int             widthMM, heightMM;
+    int widthMM, heightMM;
 
     // The window whose video mode is current on this monitor
-    _GLFWwindow*    window;
+    _GLFWwindow *window;
 
-    GLFWvidmode*    modes;
-    int             modeCount;
-    GLFWvidmode     currentMode;
+    GLFWvidmode *modes;
+    int modeCount;
+    GLFWvidmode currentMode;
 
-    GLFWgammaramp   originalRamp;
-    GLFWgammaramp   currentRamp;
+    GLFWgammaramp originalRamp;
+    GLFWgammaramp currentRamp;
 
     // This is defined in the window API's platform.h
     _GLFW_PLATFORM_MONITOR_STATE;
@@ -482,7 +493,7 @@ struct _GLFWmonitor
 //
 struct _GLFWcursor
 {
-    _GLFWcursor*    next;
+    _GLFWcursor *next;
 
     // This is defined in the window API's platform.h
     _GLFW_PLATFORM_CURSOR_STATE;
@@ -492,18 +503,18 @@ struct _GLFWcursor
 //
 struct _GLFWmapelement
 {
-    uint8_t         type;
-    uint8_t         index;
-    int8_t          axisScale;
-    int8_t          axisOffset;
+    uint8_t type;
+    uint8_t index;
+    int8_t axisScale;
+    int8_t axisOffset;
 };
 
 // Gamepad mapping structure
 //
 struct _GLFWmapping
 {
-    char            name[128];
-    char            guid[33];
+    char name[128];
+    char guid[33];
     _GLFWmapelement buttons[15];
     _GLFWmapelement axes[6];
 };
@@ -512,17 +523,17 @@ struct _GLFWmapping
 //
 struct _GLFWjoystick
 {
-    GLFWbool        present;
-    float*          axes;
-    int             axisCount;
-    unsigned char*  buttons;
-    int             buttonCount;
-    unsigned char*  hats;
-    int             hatCount;
-    char            name[128];
-    void*           userPointer;
-    char            guid[33];
-    _GLFWmapping*   mapping;
+    GLFWbool present;
+    float *axes;
+    int axisCount;
+    unsigned char *buttons;
+    int buttonCount;
+    unsigned char *hats;
+    int hatCount;
+    char name[128];
+    void *userPointer;
+    char guid[33];
+    _GLFWmapping *mapping;
 
     // This is defined in the joystick API's joystick.h
     _GLFW_PLATFORM_JOYSTICK_STATE;
@@ -548,64 +559,68 @@ struct _GLFWmutex
 //
 struct _GLFWlibrary
 {
-    GLFWbool            initialized;
-    GLFWallocator       allocator;
+    GLFWbool initialized;
+    GLFWallocator allocator;
 
-    struct {
+    struct
+    {
         _GLFWinitconfig init;
-        _GLFWfbconfig   framebuffer;
-        _GLFWwndconfig  window;
-        _GLFWctxconfig  context;
-        int             refreshRate;
+        _GLFWfbconfig framebuffer;
+        _GLFWwndconfig window;
+        _GLFWctxconfig context;
+        int refreshRate;
     } hints;
 
-    _GLFWerror*         errorListHead;
-    _GLFWcursor*        cursorListHead;
-    _GLFWwindow*        windowListHead;
+    _GLFWerror *errorListHead;
+    _GLFWcursor *cursorListHead;
+    _GLFWwindow *windowListHead;
 
-    _GLFWmonitor**      monitors;
-    int                 monitorCount;
+    _GLFWmonitor **monitors;
+    int monitorCount;
 
-    GLFWbool            joysticksInitialized;
-    _GLFWjoystick       joysticks[GLFW_JOYSTICK_LAST + 1];
-    _GLFWmapping*       mappings;
-    int                 mappingCount;
+    GLFWbool joysticksInitialized;
+    _GLFWjoystick joysticks[GLFW_JOYSTICK_LAST + 1];
+    _GLFWmapping *mappings;
+    int mappingCount;
 
-    _GLFWtls            errorSlot;
-    _GLFWtls            contextSlot;
-    _GLFWtls            usercontextSlot;
-    _GLFWmutex          errorLock;
+    _GLFWtls errorSlot;
+    _GLFWtls contextSlot;
+    _GLFWtls usercontextSlot;
+    _GLFWmutex errorLock;
 
-    struct {
-        uint64_t        offset;
+    struct
+    {
+        uint64_t offset;
         // This is defined in the platform's time.h
         _GLFW_PLATFORM_LIBRARY_TIMER_STATE;
     } timer;
 
-    struct {
-        GLFWbool        available;
-        void*           handle;
-        char*           extensions[2];
+    struct
+    {
+        GLFWbool available;
+        void *handle;
+        char *extensions[2];
 #if !defined(_GLFW_VULKAN_STATIC)
         PFN_vkEnumerateInstanceExtensionProperties EnumerateInstanceExtensionProperties;
         PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
 #endif
-        GLFWbool        KHR_surface;
+        GLFWbool KHR_surface;
 #if defined(_GLFW_WIN32)
-        GLFWbool        KHR_win32_surface;
+        GLFWbool KHR_win32_surface;
 #elif defined(_GLFW_COCOA)
-        GLFWbool        MVK_macos_surface;
-        GLFWbool        EXT_metal_surface;
+        GLFWbool MVK_macos_surface;
+        GLFWbool EXT_metal_surface;
 #elif defined(_GLFW_X11)
-        GLFWbool        KHR_xlib_surface;
-        GLFWbool        KHR_xcb_surface;
+        GLFWbool KHR_xlib_surface;
+        GLFWbool KHR_xcb_surface;
 #elif defined(_GLFW_WAYLAND)
-        GLFWbool        KHR_wayland_surface;
+        GLFWbool KHR_wayland_surface;
 #endif
     } vk;
 
-    struct {
-        GLFWmonitorfun  monitor;
+    struct
+    {
+        GLFWmonitorfun monitor;
         GLFWjoystickfun joystick;
     } callbacks;
 
@@ -625,206 +640,202 @@ struct _GLFWlibrary
 //
 extern _GLFWlibrary _glfw;
 
-
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW platform API                      //////
 //////////////////////////////////////////////////////////////////////////
 
 int _glfwPlatformInit(void);
 void _glfwPlatformTerminate(void);
-const char* _glfwPlatformGetVersionString(void);
+const char *_glfwPlatformGetVersionString(void);
 
-void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos);
-void _glfwPlatformSetCursorPos(_GLFWwindow* window, double xpos, double ypos);
-void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode);
+void _glfwPlatformGetCursorPos(_GLFWwindow *window, double *xpos, double *ypos);
+void _glfwPlatformSetCursorPos(_GLFWwindow *window, double xpos, double ypos);
+void _glfwPlatformSetCursorMode(_GLFWwindow *window, int mode);
 void _glfwPlatformSetRawMouseMotion(_GLFWwindow *window, GLFWbool enabled);
 GLFWbool _glfwPlatformRawMouseMotionSupported(void);
-int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
-                              const GLFWimage* image, int xhot, int yhot);
-int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape);
-void _glfwPlatformDestroyCursor(_GLFWcursor* cursor);
-void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor);
+int _glfwPlatformCreateCursor(_GLFWcursor *cursor,
+                              const GLFWimage *image, int xhot, int yhot);
+int _glfwPlatformCreateStandardCursor(_GLFWcursor *cursor, int shape);
+void _glfwPlatformDestroyCursor(_GLFWcursor *cursor);
+void _glfwPlatformSetCursor(_GLFWwindow *window, _GLFWcursor *cursor);
 
-const char* _glfwPlatformGetScancodeName(int scancode);
+const char *_glfwPlatformGetScancodeName(int scancode);
 int _glfwPlatformGetKeyScancode(int key);
 
-void _glfwPlatformFreeMonitor(_GLFWmonitor* monitor);
-void _glfwPlatformGetMonitorPos(_GLFWmonitor* monitor, int* xpos, int* ypos);
-void _glfwPlatformGetMonitorContentScale(_GLFWmonitor* monitor,
-                                         float* xscale, float* yscale);
-void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor* monitor, int* xpos, int* ypos, int *width, int *height);
-GLFWvidmode* _glfwPlatformGetVideoModes(_GLFWmonitor* monitor, int* count);
-void _glfwPlatformGetVideoMode(_GLFWmonitor* monitor, GLFWvidmode* mode);
-GLFWbool _glfwPlatformGetGammaRamp(_GLFWmonitor* monitor, GLFWgammaramp* ramp);
-void _glfwPlatformSetGammaRamp(_GLFWmonitor* monitor, const GLFWgammaramp* ramp);
+void _glfwPlatformFreeMonitor(_GLFWmonitor *monitor);
+void _glfwPlatformGetMonitorPos(_GLFWmonitor *monitor, int *xpos, int *ypos);
+void _glfwPlatformGetMonitorContentScale(_GLFWmonitor *monitor,
+                                         float *xscale, float *yscale);
+void _glfwPlatformGetMonitorWorkarea(_GLFWmonitor *monitor, int *xpos, int *ypos, int *width, int *height);
+GLFWvidmode *_glfwPlatformGetVideoModes(_GLFWmonitor *monitor, int *count);
+void _glfwPlatformGetVideoMode(_GLFWmonitor *monitor, GLFWvidmode *mode);
+GLFWbool _glfwPlatformGetGammaRamp(_GLFWmonitor *monitor, GLFWgammaramp *ramp);
+void _glfwPlatformSetGammaRamp(_GLFWmonitor *monitor, const GLFWgammaramp *ramp);
 
-void _glfwPlatformSetClipboardString(const char* string);
-const char* _glfwPlatformGetClipboardString(void);
+void _glfwPlatformSetClipboardString(const char *string);
+const char *_glfwPlatformGetClipboardString(void);
 
 GLFWbool _glfwPlatformInitJoysticks(void);
 void _glfwPlatformTerminateJoysticks(void);
-int _glfwPlatformPollJoystick(_GLFWjoystick* js, int mode);
-void _glfwPlatformUpdateGamepadGUID(char* guid);
+int _glfwPlatformPollJoystick(_GLFWjoystick *js, int mode);
+void _glfwPlatformUpdateGamepadGUID(char *guid);
 
 uint64_t _glfwPlatformGetTimerValue(void);
 uint64_t _glfwPlatformGetTimerFrequency(void);
 
-int _glfwPlatformCreateWindow(_GLFWwindow* window,
-                              const _GLFWwndconfig* wndconfig,
-                              const _GLFWctxconfig* ctxconfig,
-                              const _GLFWfbconfig* fbconfig);
-void _glfwPlatformDestroyWindow(_GLFWwindow* window);
-void _glfwPlatformSetWindowTitle(_GLFWwindow* window, const char* title);
-void _glfwPlatformSetWindowIcon(_GLFWwindow* window,
-                                int count, const GLFWimage* images);
-void _glfwPlatformGetWindowPos(_GLFWwindow* window, int* xpos, int* ypos);
-void _glfwPlatformSetWindowPos(_GLFWwindow* window, int xpos, int ypos);
-void _glfwPlatformGetWindowSize(_GLFWwindow* window, int* width, int* height);
-void _glfwPlatformSetWindowSize(_GLFWwindow* window, int width, int height);
-void _glfwPlatformSetWindowSizeLimits(_GLFWwindow* window,
+int _glfwPlatformCreateWindow(_GLFWwindow *window,
+                              const _GLFWwndconfig *wndconfig,
+                              const _GLFWctxconfig *ctxconfig,
+                              const _GLFWfbconfig *fbconfig);
+void _glfwPlatformDestroyWindow(_GLFWwindow *window);
+void _glfwPlatformSetWindowTitle(_GLFWwindow *window, const char *title);
+void _glfwPlatformSetWindowIcon(_GLFWwindow *window,
+                                int count, const GLFWimage *images);
+void _glfwPlatformGetWindowPos(_GLFWwindow *window, int *xpos, int *ypos);
+void _glfwPlatformSetWindowPos(_GLFWwindow *window, int xpos, int ypos);
+void _glfwPlatformGetWindowSize(_GLFWwindow *window, int *width, int *height);
+void _glfwPlatformSetWindowSize(_GLFWwindow *window, int width, int height);
+void _glfwPlatformSetWindowSizeLimits(_GLFWwindow *window,
                                       int minwidth, int minheight,
                                       int maxwidth, int maxheight);
-void _glfwPlatformSetWindowAspectRatio(_GLFWwindow* window, int numer, int denom);
-void _glfwPlatformGetFramebufferSize(_GLFWwindow* window, int* width, int* height);
-void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
-                                     int* left, int* top,
-                                     int* right, int* bottom);
-void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
-                                        float* xscale, float* yscale);
-void _glfwPlatformIconifyWindow(_GLFWwindow* window);
-void _glfwPlatformRestoreWindow(_GLFWwindow* window);
-void _glfwPlatformMaximizeWindow(_GLFWwindow* window);
-void _glfwPlatformShowWindow(_GLFWwindow* window);
-void _glfwPlatformHideWindow(_GLFWwindow* window);
-void _glfwPlatformRequestWindowAttention(_GLFWwindow* window);
-void _glfwPlatformFocusWindow(_GLFWwindow* window);
-void _glfwPlatformSetWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor,
+void _glfwPlatformSetWindowAspectRatio(_GLFWwindow *window, int numer, int denom);
+void _glfwPlatformGetFramebufferSize(_GLFWwindow *window, int *width, int *height);
+void _glfwPlatformGetWindowFrameSize(_GLFWwindow *window,
+                                     int *left, int *top,
+                                     int *right, int *bottom);
+void _glfwPlatformGetWindowContentScale(_GLFWwindow *window,
+                                        float *xscale, float *yscale);
+void _glfwPlatformIconifyWindow(_GLFWwindow *window);
+void _glfwPlatformRestoreWindow(_GLFWwindow *window);
+void _glfwPlatformMaximizeWindow(_GLFWwindow *window);
+void _glfwPlatformShowWindow(_GLFWwindow *window);
+void _glfwPlatformHideWindow(_GLFWwindow *window);
+void _glfwPlatformRequestWindowAttention(_GLFWwindow *window);
+void _glfwPlatformFocusWindow(_GLFWwindow *window);
+void _glfwPlatformSetWindowMonitor(_GLFWwindow *window, _GLFWmonitor *monitor,
                                    int xpos, int ypos, int width, int height,
                                    int refreshRate);
-int _glfwPlatformWindowFocused(_GLFWwindow* window);
-int _glfwPlatformWindowIconified(_GLFWwindow* window);
-int _glfwPlatformWindowVisible(_GLFWwindow* window);
-int _glfwPlatformWindowMaximized(_GLFWwindow* window);
-int _glfwPlatformWindowHovered(_GLFWwindow* window);
-int _glfwPlatformFramebufferTransparent(_GLFWwindow* window);
-float _glfwPlatformGetWindowOpacity(_GLFWwindow* window);
-void _glfwPlatformSetWindowResizable(_GLFWwindow* window, GLFWbool enabled);
-void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled);
-void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled);
-void _glfwPlatformSetWindowMousePassthrough(_GLFWwindow* window, GLFWbool enabled);
-void _glfwPlatformSetWindowOpacity(_GLFWwindow* window, float opacity);
+int _glfwPlatformWindowFocused(_GLFWwindow *window);
+int _glfwPlatformWindowIconified(_GLFWwindow *window);
+int _glfwPlatformWindowVisible(_GLFWwindow *window);
+int _glfwPlatformWindowMaximized(_GLFWwindow *window);
+int _glfwPlatformWindowHovered(_GLFWwindow *window);
+int _glfwPlatformFramebufferTransparent(_GLFWwindow *window);
+float _glfwPlatformGetWindowOpacity(_GLFWwindow *window);
+void _glfwPlatformSetWindowResizable(_GLFWwindow *window, GLFWbool enabled);
+void _glfwPlatformSetWindowDecorated(_GLFWwindow *window, GLFWbool enabled);
+void _glfwPlatformSetWindowFloating(_GLFWwindow *window, GLFWbool enabled);
+void _glfwPlatformSetWindowMousePassthrough(_GLFWwindow *window, GLFWbool enabled);
+void _glfwPlatformSetWindowOpacity(_GLFWwindow *window, float opacity);
 
 void _glfwPlatformPollEvents(void);
 void _glfwPlatformWaitEvents(void);
 void _glfwPlatformWaitEventsTimeout(double timeout);
 void _glfwPlatformPostEmptyEvent(void);
 
-_GLFWusercontext* _glfwPlatformCreateUserContext(_GLFWwindow* window);
+_GLFWusercontext *_glfwPlatformCreateUserContext(_GLFWwindow *window);
 
-EGLenum _glfwPlatformGetEGLPlatform(EGLint** attribs);
+EGLenum _glfwPlatformGetEGLPlatform(EGLint **attribs);
 EGLNativeDisplayType _glfwPlatformGetEGLNativeDisplay(void);
-EGLNativeWindowType _glfwPlatformGetEGLNativeWindow(_GLFWwindow* window);
+EGLNativeWindowType _glfwPlatformGetEGLNativeWindow(_GLFWwindow *window);
 
-void _glfwPlatformGetRequiredInstanceExtensions(char** extensions);
+void _glfwPlatformGetRequiredInstanceExtensions(char **extensions);
 int _glfwPlatformGetPhysicalDevicePresentationSupport(VkInstance instance,
                                                       VkPhysicalDevice device,
                                                       uint32_t queuefamily);
 VkResult _glfwPlatformCreateWindowSurface(VkInstance instance,
-                                          _GLFWwindow* window,
-                                          const VkAllocationCallbacks* allocator,
-                                          VkSurfaceKHR* surface);
+                                          _GLFWwindow *window,
+                                          const VkAllocationCallbacks *allocator,
+                                          VkSurfaceKHR *surface);
 
-GLFWbool _glfwPlatformCreateTls(_GLFWtls* tls);
-void _glfwPlatformDestroyTls(_GLFWtls* tls);
-void* _glfwPlatformGetTls(_GLFWtls* tls);
-void _glfwPlatformSetTls(_GLFWtls* tls, void* value);
+GLFWbool _glfwPlatformCreateTls(_GLFWtls *tls);
+void _glfwPlatformDestroyTls(_GLFWtls *tls);
+void *_glfwPlatformGetTls(_GLFWtls *tls);
+void _glfwPlatformSetTls(_GLFWtls *tls, void *value);
 
-GLFWbool _glfwPlatformCreateMutex(_GLFWmutex* mutex);
-void _glfwPlatformDestroyMutex(_GLFWmutex* mutex);
-void _glfwPlatformLockMutex(_GLFWmutex* mutex);
-void _glfwPlatformUnlockMutex(_GLFWmutex* mutex);
-
+GLFWbool _glfwPlatformCreateMutex(_GLFWmutex *mutex);
+void _glfwPlatformDestroyMutex(_GLFWmutex *mutex);
+void _glfwPlatformLockMutex(_GLFWmutex *mutex);
+void _glfwPlatformUnlockMutex(_GLFWmutex *mutex);
 
 //////////////////////////////////////////////////////////////////////////
 //////                         GLFW event API                       //////
 //////////////////////////////////////////////////////////////////////////
 
-void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused);
-void _glfwInputWindowPos(_GLFWwindow* window, int xpos, int ypos);
-void _glfwInputWindowSize(_GLFWwindow* window, int width, int height);
-void _glfwInputFramebufferSize(_GLFWwindow* window, int width, int height);
-void _glfwInputWindowContentScale(_GLFWwindow* window,
+void _glfwInputWindowFocus(_GLFWwindow *window, GLFWbool focused);
+void _glfwInputWindowPos(_GLFWwindow *window, int xpos, int ypos);
+void _glfwInputWindowSize(_GLFWwindow *window, int width, int height);
+void _glfwInputFramebufferSize(_GLFWwindow *window, int width, int height);
+void _glfwInputWindowContentScale(_GLFWwindow *window,
                                   float xscale, float yscale);
-void _glfwInputWindowIconify(_GLFWwindow* window, GLFWbool iconified);
-void _glfwInputWindowMaximize(_GLFWwindow* window, GLFWbool maximized);
-void _glfwInputWindowDamage(_GLFWwindow* window);
-void _glfwInputWindowCloseRequest(_GLFWwindow* window);
-void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor);
+void _glfwInputWindowIconify(_GLFWwindow *window, GLFWbool iconified);
+void _glfwInputWindowMaximize(_GLFWwindow *window, GLFWbool maximized);
+void _glfwInputWindowDamage(_GLFWwindow *window);
+void _glfwInputWindowCloseRequest(_GLFWwindow *window);
+void _glfwInputWindowMonitor(_GLFWwindow *window, _GLFWmonitor *monitor);
 
-void _glfwInputKey(_GLFWwindow* window,
+void _glfwInputKey(_GLFWwindow *window,
                    int key, int scancode, int action, int mods);
-void _glfwInputChar(_GLFWwindow* window,
+void _glfwInputChar(_GLFWwindow *window,
                     unsigned int codepoint, int mods, GLFWbool plain);
-void _glfwInputScroll(_GLFWwindow* window, double xoffset, double yoffset);
-void _glfwInputMouseClick(_GLFWwindow* window, int button, int action, int mods);
-void _glfwInputCursorPos(_GLFWwindow* window, double xpos, double ypos);
-void _glfwInputCursorEnter(_GLFWwindow* window, GLFWbool entered);
-void _glfwInputDrop(_GLFWwindow* window, int count, const char** names);
-void _glfwInputJoystick(_GLFWjoystick* js, int event);
-void _glfwInputJoystickAxis(_GLFWjoystick* js, int axis, float value);
-void _glfwInputJoystickButton(_GLFWjoystick* js, int button, char value);
-void _glfwInputJoystickHat(_GLFWjoystick* js, int hat, char value);
+void _glfwInputScroll(_GLFWwindow *window, double xoffset, double yoffset);
+void _glfwInputMouseClick(_GLFWwindow *window, int button, int action, int mods);
+void _glfwInputCursorPos(_GLFWwindow *window, double xpos, double ypos);
+void _glfwInputCursorEnter(_GLFWwindow *window, GLFWbool entered);
+void _glfwInputDrop(_GLFWwindow *window, int count, const char **names);
+void _glfwInputJoystick(_GLFWjoystick *js, int event);
+void _glfwInputJoystickAxis(_GLFWjoystick *js, int axis, float value);
+void _glfwInputJoystickButton(_GLFWjoystick *js, int button, char value);
+void _glfwInputJoystickHat(_GLFWjoystick *js, int hat, char value);
 
-void _glfwInputMonitor(_GLFWmonitor* monitor, int action, int placement);
-void _glfwInputMonitorWindow(_GLFWmonitor* monitor, _GLFWwindow* window);
+void _glfwInputMonitor(_GLFWmonitor *monitor, int action, int placement);
+void _glfwInputMonitorWindow(_GLFWmonitor *monitor, _GLFWwindow *window);
 
 #if defined(__GNUC__)
-void _glfwInputError(int code, const char* format, ...)
+void _glfwInputError(int code, const char *format, ...)
     __attribute__((format(printf, 2, 3)));
 #else
-void _glfwInputError(int code, const char* format, ...);
+void _glfwInputError(int code, const char *format, ...);
 #endif
-
 
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW internal API                      //////
 //////////////////////////////////////////////////////////////////////////
 
-GLFWbool _glfwStringInExtensionString(const char* string, const char* extensions);
-const _GLFWfbconfig* _glfwChooseFBConfig(const _GLFWfbconfig* desired,
-                                         const _GLFWfbconfig* alternatives,
+GLFWbool _glfwStringInExtensionString(const char *string, const char *extensions);
+const _GLFWfbconfig *_glfwChooseFBConfig(const _GLFWfbconfig *desired,
+                                         const _GLFWfbconfig *alternatives,
                                          unsigned int count);
-GLFWbool _glfwRefreshContextAttribs(_GLFWwindow* window,
-                                    const _GLFWctxconfig* ctxconfig);
-GLFWbool _glfwIsValidContextConfig(const _GLFWctxconfig* ctxconfig);
+GLFWbool _glfwRefreshContextAttribs(_GLFWwindow *window,
+                                    const _GLFWctxconfig *ctxconfig);
+GLFWbool _glfwIsValidContextConfig(const _GLFWctxconfig *ctxconfig);
 
-const GLFWvidmode* _glfwChooseVideoMode(_GLFWmonitor* monitor,
-                                        const GLFWvidmode* desired);
-int _glfwCompareVideoModes(const GLFWvidmode* first, const GLFWvidmode* second);
-_GLFWmonitor* _glfwAllocMonitor(const char* name, int widthMM, int heightMM);
-void _glfwFreeMonitor(_GLFWmonitor* monitor);
-void _glfwAllocGammaArrays(GLFWgammaramp* ramp, unsigned int size);
-void _glfwFreeGammaArrays(GLFWgammaramp* ramp);
-void _glfwSplitBPP(int bpp, int* red, int* green, int* blue);
+const GLFWvidmode *_glfwChooseVideoMode(_GLFWmonitor *monitor,
+                                        const GLFWvidmode *desired);
+int _glfwCompareVideoModes(const GLFWvidmode *first, const GLFWvidmode *second);
+_GLFWmonitor *_glfwAllocMonitor(const char *name, int widthMM, int heightMM);
+void _glfwFreeMonitor(_GLFWmonitor *monitor);
+void _glfwAllocGammaArrays(GLFWgammaramp *ramp, unsigned int size);
+void _glfwFreeGammaArrays(GLFWgammaramp *ramp);
+void _glfwSplitBPP(int bpp, int *red, int *green, int *blue);
 
 void _glfwInitGamepadMappings(void);
-_GLFWjoystick* _glfwAllocJoystick(const char* name,
-                                  const char* guid,
+_GLFWjoystick *_glfwAllocJoystick(const char *name,
+                                  const char *guid,
                                   int axisCount,
                                   int buttonCount,
                                   int hatCount);
-void _glfwFreeJoystick(_GLFWjoystick* js);
-void _glfwCenterCursorInContentArea(_GLFWwindow* window);
+void _glfwFreeJoystick(_GLFWjoystick *js);
+void _glfwCenterCursorInContentArea(_GLFWwindow *window);
 
 GLFWbool _glfwInitVulkan(int mode);
 void _glfwTerminateVulkan(void);
-const char* _glfwGetVulkanResultString(VkResult result);
+const char *_glfwGetVulkanResultString(VkResult result);
 
-char* _glfw_strdup(const char* source);
+char *_glfw_strdup(const char *source);
 float _glfw_fminf(float a, float b);
 float _glfw_fmaxf(float a, float b);
 
-void* _glfw_calloc(size_t count, size_t size);
-void* _glfw_realloc(void* pointer, size_t size);
-void _glfw_free(void* pointer);
-
+void *_glfw_calloc(size_t count, size_t size);
+void *_glfw_realloc(void *pointer, size_t size);
+void _glfw_free(void *pointer);

--- a/src/window.c
+++ b/src/window.c
@@ -35,23 +35,22 @@
 #include <stdlib.h>
 #include <float.h>
 
-
 //////////////////////////////////////////////////////////////////////////
 //////                         GLFW event API                       //////
 //////////////////////////////////////////////////////////////////////////
 
 // Notifies shared code that a window has lost or received input focus
 //
-void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused)
+void _glfwInputWindowFocus(_GLFWwindow *window, GLFWbool focused)
 {
     if (window->callbacks.focus)
-        window->callbacks.focus((GLFWwindow*) window, focused);
+        window->callbacks.focus((GLFWwindow *)window, focused);
 
     if (!focused)
     {
         int key, button;
 
-        for (key = 0;  key <= GLFW_KEY_LAST;  key++)
+        for (key = 0; key <= GLFW_KEY_LAST; key++)
         {
             if (window->keys[key] == GLFW_PRESS)
             {
@@ -60,7 +59,7 @@ void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused)
             }
         }
 
-        for (button = 0;  button <= GLFW_MOUSE_BUTTON_LAST;  button++)
+        for (button = 0; button <= GLFW_MOUSE_BUTTON_LAST; button++)
         {
             if (window->mouseButtons[button] == GLFW_PRESS)
                 _glfwInputMouseClick(window, button, GLFW_RELEASE, 0);
@@ -71,76 +70,76 @@ void _glfwInputWindowFocus(_GLFWwindow* window, GLFWbool focused)
 // Notifies shared code that a window has moved
 // The position is specified in content area relative screen coordinates
 //
-void _glfwInputWindowPos(_GLFWwindow* window, int x, int y)
+void _glfwInputWindowPos(_GLFWwindow *window, int x, int y)
 {
     if (window->callbacks.pos)
-        window->callbacks.pos((GLFWwindow*) window, x, y);
+        window->callbacks.pos((GLFWwindow *)window, x, y);
 }
 
 // Notifies shared code that a window has been resized
 // The size is specified in screen coordinates
 //
-void _glfwInputWindowSize(_GLFWwindow* window, int width, int height)
+void _glfwInputWindowSize(_GLFWwindow *window, int width, int height)
 {
     if (window->callbacks.size)
-        window->callbacks.size((GLFWwindow*) window, width, height);
+        window->callbacks.size((GLFWwindow *)window, width, height);
 }
 
 // Notifies shared code that a window has been iconified or restored
 //
-void _glfwInputWindowIconify(_GLFWwindow* window, GLFWbool iconified)
+void _glfwInputWindowIconify(_GLFWwindow *window, GLFWbool iconified)
 {
     if (window->callbacks.iconify)
-        window->callbacks.iconify((GLFWwindow*) window, iconified);
+        window->callbacks.iconify((GLFWwindow *)window, iconified);
 }
 
 // Notifies shared code that a window has been maximized or restored
 //
-void _glfwInputWindowMaximize(_GLFWwindow* window, GLFWbool maximized)
+void _glfwInputWindowMaximize(_GLFWwindow *window, GLFWbool maximized)
 {
     if (window->callbacks.maximize)
-        window->callbacks.maximize((GLFWwindow*) window, maximized);
+        window->callbacks.maximize((GLFWwindow *)window, maximized);
 }
 
 // Notifies shared code that a window framebuffer has been resized
 // The size is specified in pixels
 //
-void _glfwInputFramebufferSize(_GLFWwindow* window, int width, int height)
+void _glfwInputFramebufferSize(_GLFWwindow *window, int width, int height)
 {
     if (window->callbacks.fbsize)
-        window->callbacks.fbsize((GLFWwindow*) window, width, height);
+        window->callbacks.fbsize((GLFWwindow *)window, width, height);
 }
 
 // Notifies shared code that a window content scale has changed
 // The scale is specified as the ratio between the current and default DPI
 //
-void _glfwInputWindowContentScale(_GLFWwindow* window, float xscale, float yscale)
+void _glfwInputWindowContentScale(_GLFWwindow *window, float xscale, float yscale)
 {
     if (window->callbacks.scale)
-        window->callbacks.scale((GLFWwindow*) window, xscale, yscale);
+        window->callbacks.scale((GLFWwindow *)window, xscale, yscale);
 }
 
 // Notifies shared code that the window contents needs updating
 //
-void _glfwInputWindowDamage(_GLFWwindow* window)
+void _glfwInputWindowDamage(_GLFWwindow *window)
 {
     if (window->callbacks.refresh)
-        window->callbacks.refresh((GLFWwindow*) window);
+        window->callbacks.refresh((GLFWwindow *)window);
 }
 
 // Notifies shared code that the user wishes to close a window
 //
-void _glfwInputWindowCloseRequest(_GLFWwindow* window)
+void _glfwInputWindowCloseRequest(_GLFWwindow *window)
 {
     window->shouldClose = GLFW_TRUE;
 
     if (window->callbacks.close)
-        window->callbacks.close((GLFWwindow*) window);
+        window->callbacks.close((GLFWwindow *)window);
 }
 
 // Notifies shared code that a window has changed its desired monitor
 //
-void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor)
+void _glfwInputWindowMonitor(_GLFWwindow *window, _GLFWmonitor *monitor)
 {
     window->monitor = monitor;
 }
@@ -149,15 +148,15 @@ void _glfwInputWindowMonitor(_GLFWwindow* window, _GLFWmonitor* monitor)
 //////                        GLFW public API                       //////
 //////////////////////////////////////////////////////////////////////////
 
-GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
-                                     const char* title,
-                                     GLFWmonitor* monitor,
-                                     GLFWwindow* share)
+GLFWAPI GLFWwindow *glfwCreateWindow(int width, int height,
+                                     const char *title,
+                                     GLFWmonitor *monitor,
+                                     GLFWwindow *share)
 {
     _GLFWfbconfig fbconfig;
     _GLFWctxconfig ctxconfig;
     _GLFWwndconfig wndconfig;
-    _GLFWwindow* window;
+    _GLFWwindow *window;
 
     assert(title != NULL);
     assert(width >= 0);
@@ -174,14 +173,14 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
         return NULL;
     }
 
-    fbconfig  = _glfw.hints.framebuffer;
+    fbconfig = _glfw.hints.framebuffer;
     ctxconfig = _glfw.hints.context;
     wndconfig = _glfw.hints.window;
 
-    wndconfig.width   = width;
-    wndconfig.height  = height;
-    wndconfig.title   = title;
-    ctxconfig.share   = (_GLFWwindow*) share;
+    wndconfig.width = width;
+    wndconfig.height = height;
+    wndconfig.title = title;
+    ctxconfig.share = (_GLFWwindow *)share;
 
     if (!_glfwIsValidContextConfig(&ctxconfig))
         return NULL;
@@ -190,35 +189,35 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     window->next = _glfw.windowListHead;
     _glfw.windowListHead = window;
 
-    window->videoMode.width       = width;
-    window->videoMode.height      = height;
-    window->videoMode.redBits     = fbconfig.redBits;
-    window->videoMode.greenBits   = fbconfig.greenBits;
-    window->videoMode.blueBits    = fbconfig.blueBits;
+    window->videoMode.width = width;
+    window->videoMode.height = height;
+    window->videoMode.redBits = fbconfig.redBits;
+    window->videoMode.greenBits = fbconfig.greenBits;
+    window->videoMode.blueBits = fbconfig.blueBits;
     window->videoMode.refreshRate = _glfw.hints.refreshRate;
 
-    window->monitor          = (_GLFWmonitor*) monitor;
-    window->resizable        = wndconfig.resizable;
-    window->decorated        = wndconfig.decorated;
-    window->autoIconify      = wndconfig.autoIconify;
-    window->floating         = wndconfig.floating;
-    window->focusOnShow      = wndconfig.focusOnShow;
+    window->monitor = (_GLFWmonitor *)monitor;
+    window->resizable = wndconfig.resizable;
+    window->decorated = wndconfig.decorated;
+    window->autoIconify = wndconfig.autoIconify;
+    window->floating = wndconfig.floating;
+    window->focusOnShow = wndconfig.focusOnShow;
     window->mousePassthrough = wndconfig.mousePassthrough;
-    window->cursorMode       = GLFW_CURSOR_NORMAL;
+    window->cursorMode = GLFW_CURSOR_NORMAL;
 
     window->doublebuffer = fbconfig.doublebuffer;
 
-    window->minwidth    = GLFW_DONT_CARE;
-    window->minheight   = GLFW_DONT_CARE;
-    window->maxwidth    = GLFW_DONT_CARE;
-    window->maxheight   = GLFW_DONT_CARE;
-    window->numer       = GLFW_DONT_CARE;
-    window->denom       = GLFW_DONT_CARE;
+    window->minwidth = GLFW_DONT_CARE;
+    window->minheight = GLFW_DONT_CARE;
+    window->maxwidth = GLFW_DONT_CARE;
+    window->maxheight = GLFW_DONT_CARE;
+    window->numer = GLFW_DONT_CARE;
+    window->denom = GLFW_DONT_CARE;
 
     // Open the actual window and create its context
     if (!_glfwPlatformCreateWindow(window, &wndconfig, &ctxconfig, &fbconfig))
     {
-        glfwDestroyWindow((GLFWwindow*) window);
+        glfwDestroyWindow((GLFWwindow *)window);
         return NULL;
     }
 
@@ -226,7 +225,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
     {
         if (!_glfwRefreshContextAttribs(window, &ctxconfig))
         {
-            glfwDestroyWindow((GLFWwindow*) window);
+            glfwDestroyWindow((GLFWwindow *)window);
             return NULL;
         }
     }
@@ -249,7 +248,7 @@ GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height,
         }
     }
 
-    return (GLFWwindow*) window;
+    return (GLFWwindow *)window;
 }
 
 void glfwDefaultWindowHints(void)
@@ -260,28 +259,28 @@ void glfwDefaultWindowHints(void)
     memset(&_glfw.hints.context, 0, sizeof(_glfw.hints.context));
     _glfw.hints.context.client = GLFW_OPENGL_API;
     _glfw.hints.context.source = GLFW_NATIVE_CONTEXT_API;
-    _glfw.hints.context.major  = 1;
-    _glfw.hints.context.minor  = 0;
+    _glfw.hints.context.major = 1;
+    _glfw.hints.context.minor = 0;
 
     // The default is a focused, visible, resizable window with decorations
     memset(&_glfw.hints.window, 0, sizeof(_glfw.hints.window));
-    _glfw.hints.window.resizable    = GLFW_TRUE;
-    _glfw.hints.window.visible      = GLFW_TRUE;
-    _glfw.hints.window.decorated    = GLFW_TRUE;
-    _glfw.hints.window.focused      = GLFW_TRUE;
-    _glfw.hints.window.autoIconify  = GLFW_TRUE;
+    _glfw.hints.window.resizable = GLFW_TRUE;
+    _glfw.hints.window.visible = GLFW_TRUE;
+    _glfw.hints.window.decorated = GLFW_TRUE;
+    _glfw.hints.window.focused = GLFW_TRUE;
+    _glfw.hints.window.autoIconify = GLFW_TRUE;
     _glfw.hints.window.centerCursor = GLFW_TRUE;
-    _glfw.hints.window.focusOnShow  = GLFW_TRUE;
+    _glfw.hints.window.focusOnShow = GLFW_TRUE;
 
     // The default is 24 bits of color, 24 bits of depth and 8 bits of stencil,
     // double buffered
     memset(&_glfw.hints.framebuffer, 0, sizeof(_glfw.hints.framebuffer));
-    _glfw.hints.framebuffer.redBits      = 8;
-    _glfw.hints.framebuffer.greenBits    = 8;
-    _glfw.hints.framebuffer.blueBits     = 8;
-    _glfw.hints.framebuffer.alphaBits    = 8;
-    _glfw.hints.framebuffer.depthBits    = 24;
-    _glfw.hints.framebuffer.stencilBits  = 8;
+    _glfw.hints.framebuffer.redBits = 8;
+    _glfw.hints.framebuffer.greenBits = 8;
+    _glfw.hints.framebuffer.blueBits = 8;
+    _glfw.hints.framebuffer.alphaBits = 8;
+    _glfw.hints.framebuffer.depthBits = 24;
+    _glfw.hints.framebuffer.stencilBits = 8;
     _glfw.hints.framebuffer.doublebuffer = GLFW_TRUE;
 
     // The default is to select the highest available refresh rate
@@ -297,150 +296,165 @@ GLFWAPI void glfwWindowHint(int hint, int value)
 
     switch (hint)
     {
-        case GLFW_RED_BITS:
-            _glfw.hints.framebuffer.redBits = value;
-            return;
-        case GLFW_GREEN_BITS:
-            _glfw.hints.framebuffer.greenBits = value;
-            return;
-        case GLFW_BLUE_BITS:
-            _glfw.hints.framebuffer.blueBits = value;
-            return;
-        case GLFW_ALPHA_BITS:
-            _glfw.hints.framebuffer.alphaBits = value;
-            return;
-        case GLFW_DEPTH_BITS:
-            _glfw.hints.framebuffer.depthBits = value;
-            return;
-        case GLFW_STENCIL_BITS:
-            _glfw.hints.framebuffer.stencilBits = value;
-            return;
-        case GLFW_ACCUM_RED_BITS:
-            _glfw.hints.framebuffer.accumRedBits = value;
-            return;
-        case GLFW_ACCUM_GREEN_BITS:
-            _glfw.hints.framebuffer.accumGreenBits = value;
-            return;
-        case GLFW_ACCUM_BLUE_BITS:
-            _glfw.hints.framebuffer.accumBlueBits = value;
-            return;
-        case GLFW_ACCUM_ALPHA_BITS:
-            _glfw.hints.framebuffer.accumAlphaBits = value;
-            return;
-        case GLFW_AUX_BUFFERS:
-            _glfw.hints.framebuffer.auxBuffers = value;
-            return;
-        case GLFW_STEREO:
-            _glfw.hints.framebuffer.stereo = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_DOUBLEBUFFER:
-            _glfw.hints.framebuffer.doublebuffer = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_TRANSPARENT_FRAMEBUFFER:
-            _glfw.hints.framebuffer.transparent = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_SAMPLES:
-            _glfw.hints.framebuffer.samples = value;
-            return;
-        case GLFW_SRGB_CAPABLE:
-            _glfw.hints.framebuffer.sRGB = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_RESIZABLE:
-            _glfw.hints.window.resizable = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_DECORATED:
-            _glfw.hints.window.decorated = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_FOCUSED:
-            _glfw.hints.window.focused = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_AUTO_ICONIFY:
-            _glfw.hints.window.autoIconify = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_FLOATING:
-            _glfw.hints.window.floating = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_MAXIMIZED:
-            _glfw.hints.window.maximized = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_VISIBLE:
-            _glfw.hints.window.visible = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_COCOA_RETINA_FRAMEBUFFER:
-            _glfw.hints.window.ns.retina = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_WIN32_KEYBOARD_MENU:
-            _glfw.hints.window.win32.keymenu = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_COCOA_GRAPHICS_SWITCHING:
-            _glfw.hints.context.nsgl.offline = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_SCALE_TO_MONITOR:
-            _glfw.hints.window.scaleToMonitor = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_CENTER_CURSOR:
-            _glfw.hints.window.centerCursor = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_FOCUS_ON_SHOW:
-            _glfw.hints.window.focusOnShow = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_MOUSE_PASSTHROUGH:
-            _glfw.hints.window.mousePassthrough = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_CLIENT_API:
-            _glfw.hints.context.client = value;
-            return;
-        case GLFW_CONTEXT_CREATION_API:
-            _glfw.hints.context.source = value;
-            return;
-        case GLFW_CONTEXT_VERSION_MAJOR:
-            _glfw.hints.context.major = value;
-            return;
-        case GLFW_CONTEXT_VERSION_MINOR:
-            _glfw.hints.context.minor = value;
-            return;
-        case GLFW_CONTEXT_ROBUSTNESS:
-            _glfw.hints.context.robustness = value;
-            return;
-        case GLFW_OPENGL_FORWARD_COMPAT:
-            _glfw.hints.context.forward = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_CONTEXT_DEBUG:
-            _glfw.hints.context.debug = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_CONTEXT_NO_ERROR:
-            _glfw.hints.context.noerror = value ? GLFW_TRUE : GLFW_FALSE;
-            return;
-        case GLFW_OPENGL_PROFILE:
-            _glfw.hints.context.profile = value;
-            return;
-        case GLFW_CONTEXT_RELEASE_BEHAVIOR:
-            _glfw.hints.context.release = value;
-            return;
-        case GLFW_REFRESH_RATE:
-            _glfw.hints.refreshRate = value;
-            return;
+    case GLFW_RED_BITS:
+        _glfw.hints.framebuffer.redBits = value;
+        return;
+    case GLFW_GREEN_BITS:
+        _glfw.hints.framebuffer.greenBits = value;
+        return;
+    case GLFW_BLUE_BITS:
+        _glfw.hints.framebuffer.blueBits = value;
+        return;
+    case GLFW_ALPHA_BITS:
+        _glfw.hints.framebuffer.alphaBits = value;
+        return;
+    case GLFW_DEPTH_BITS:
+        _glfw.hints.framebuffer.depthBits = value;
+        return;
+    case GLFW_STENCIL_BITS:
+        _glfw.hints.framebuffer.stencilBits = value;
+        return;
+    case GLFW_ACCUM_RED_BITS:
+        _glfw.hints.framebuffer.accumRedBits = value;
+        return;
+    case GLFW_ACCUM_GREEN_BITS:
+        _glfw.hints.framebuffer.accumGreenBits = value;
+        return;
+    case GLFW_ACCUM_BLUE_BITS:
+        _glfw.hints.framebuffer.accumBlueBits = value;
+        return;
+    case GLFW_ACCUM_ALPHA_BITS:
+        _glfw.hints.framebuffer.accumAlphaBits = value;
+        return;
+    case GLFW_AUX_BUFFERS:
+        _glfw.hints.framebuffer.auxBuffers = value;
+        return;
+    case GLFW_STEREO:
+        _glfw.hints.framebuffer.stereo = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_DOUBLEBUFFER:
+        _glfw.hints.framebuffer.doublebuffer = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_TRANSPARENT_FRAMEBUFFER:
+        _glfw.hints.framebuffer.transparent = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_SAMPLES:
+        _glfw.hints.framebuffer.samples = value;
+        return;
+    case GLFW_SRGB_CAPABLE:
+        _glfw.hints.framebuffer.sRGB = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_RESIZABLE:
+        _glfw.hints.window.resizable = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_DECORATED:
+        _glfw.hints.window.decorated = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_FOCUSED:
+        _glfw.hints.window.focused = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_AUTO_ICONIFY:
+        _glfw.hints.window.autoIconify = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_FLOATING:
+        _glfw.hints.window.floating = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_MAXIMIZED:
+        _glfw.hints.window.maximized = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_VISIBLE:
+        _glfw.hints.window.visible = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_COCOA_RETINA_FRAMEBUFFER:
+        _glfw.hints.window.ns.retina = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_WIN32_KEYBOARD_MENU:
+        _glfw.hints.window.win32.keymenu = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_COCOA_GRAPHICS_SWITCHING:
+        _glfw.hints.context.nsgl.offline = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_SCALE_TO_MONITOR:
+        _glfw.hints.window.scaleToMonitor = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_CENTER_CURSOR:
+        _glfw.hints.window.centerCursor = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_FOCUS_ON_SHOW:
+        _glfw.hints.window.focusOnShow = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_MOUSE_PASSTHROUGH:
+        _glfw.hints.window.mousePassthrough = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_NET_WM_WINDOW_TYPE_DESKTOP:
+        _glfw.hints.window.isDesktopWindow = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_STICKY_WINDOW:
+        _glfw.hints.window.sticky = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_BELOW:
+        _glfw.hints.window.below = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_SKIP_TASKBAR:
+        _glfw.hints.window.skipTaskbar = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_SKIP_PAGER:
+        _glfw.hints.window.skipPager = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_CLIENT_API:
+        _glfw.hints.context.client = value;
+        return;
+    case GLFW_CONTEXT_CREATION_API:
+        _glfw.hints.context.source = value;
+        return;
+    case GLFW_CONTEXT_VERSION_MAJOR:
+        _glfw.hints.context.major = value;
+        return;
+    case GLFW_CONTEXT_VERSION_MINOR:
+        _glfw.hints.context.minor = value;
+        return;
+    case GLFW_CONTEXT_ROBUSTNESS:
+        _glfw.hints.context.robustness = value;
+        return;
+    case GLFW_OPENGL_FORWARD_COMPAT:
+        _glfw.hints.context.forward = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_CONTEXT_DEBUG:
+        _glfw.hints.context.debug = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_CONTEXT_NO_ERROR:
+        _glfw.hints.context.noerror = value ? GLFW_TRUE : GLFW_FALSE;
+        return;
+    case GLFW_OPENGL_PROFILE:
+        _glfw.hints.context.profile = value;
+        return;
+    case GLFW_CONTEXT_RELEASE_BEHAVIOR:
+        _glfw.hints.context.release = value;
+        return;
+    case GLFW_REFRESH_RATE:
+        _glfw.hints.refreshRate = value;
+        return;
     }
 
     _glfwInputError(GLFW_INVALID_ENUM, "Invalid window hint 0x%08X", hint);
 }
 
-GLFWAPI void glfwWindowHintPointer(int hint, void* value)
+GLFWAPI void glfwWindowHintPointer(int hint, void *value)
 {
     _GLFW_REQUIRE_INIT();
 
     switch (hint)
     {
-        case GLFW_NATIVE_PARENT_HANDLE:
-	        _glfw.hints.window.nativeParent = value;
-            break;
-        default:
-            _glfwInputError(GLFW_INVALID_ENUM, "Invalid window hint %i", hint);
-            break;
+    case GLFW_NATIVE_PARENT_HANDLE:
+        _glfw.hints.window.nativeParent = value;
+        break;
+    default:
+        _glfwInputError(GLFW_INVALID_ENUM, "Invalid window hint %i", hint);
+        break;
     }
 }
 
-GLFWAPI void glfwWindowHintString(int hint, const char* value)
+GLFWAPI void glfwWindowHintString(int hint, const char *value)
 {
     assert(value != NULL);
 
@@ -448,26 +462,26 @@ GLFWAPI void glfwWindowHintString(int hint, const char* value)
 
     switch (hint)
     {
-        case GLFW_COCOA_FRAME_NAME:
-            strncpy(_glfw.hints.window.ns.frameName, value,
-                    sizeof(_glfw.hints.window.ns.frameName) - 1);
-            return;
-        case GLFW_X11_CLASS_NAME:
-            strncpy(_glfw.hints.window.x11.className, value,
-                    sizeof(_glfw.hints.window.x11.className) - 1);
-            return;
-        case GLFW_X11_INSTANCE_NAME:
-            strncpy(_glfw.hints.window.x11.instanceName, value,
-                    sizeof(_glfw.hints.window.x11.instanceName) - 1);
-            return;
+    case GLFW_COCOA_FRAME_NAME:
+        strncpy(_glfw.hints.window.ns.frameName, value,
+                sizeof(_glfw.hints.window.ns.frameName) - 1);
+        return;
+    case GLFW_X11_CLASS_NAME:
+        strncpy(_glfw.hints.window.x11.className, value,
+                sizeof(_glfw.hints.window.x11.className) - 1);
+        return;
+    case GLFW_X11_INSTANCE_NAME:
+        strncpy(_glfw.hints.window.x11.instanceName, value,
+                sizeof(_glfw.hints.window.x11.instanceName) - 1);
+        return;
     }
 
     _glfwInputError(GLFW_INVALID_ENUM, "Invalid window hint string 0x%08X", hint);
 }
 
-GLFWAPI void glfwDestroyWindow(GLFWwindow* handle)
+GLFWAPI void glfwDestroyWindow(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
 
     _GLFW_REQUIRE_INIT();
 
@@ -487,7 +501,7 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow* handle)
 
     // Unlink window from global linked list
     {
-        _GLFWwindow** prev = &_glfw.windowListHead;
+        _GLFWwindow **prev = &_glfw.windowListHead;
 
         while (*prev != window)
             prev = &((*prev)->next);
@@ -498,27 +512,27 @@ GLFWAPI void glfwDestroyWindow(GLFWwindow* handle)
     _glfw_free(window);
 }
 
-GLFWAPI int glfwWindowShouldClose(GLFWwindow* handle)
+GLFWAPI int glfwWindowShouldClose(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(0);
     return window->shouldClose;
 }
 
-GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* handle, int value)
+GLFWAPI void glfwSetWindowShouldClose(GLFWwindow *handle, int value)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
     window->shouldClose = value;
 }
 
-GLFWAPI void glfwSetWindowTitle(GLFWwindow* handle, const char* title)
+GLFWAPI void glfwSetWindowTitle(GLFWwindow *handle, const char *title)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
     assert(title != NULL);
 
@@ -526,10 +540,10 @@ GLFWAPI void glfwSetWindowTitle(GLFWwindow* handle, const char* title)
     _glfwPlatformSetWindowTitle(window, title);
 }
 
-GLFWAPI void glfwSetWindowIcon(GLFWwindow* handle,
-                               int count, const GLFWimage* images)
+GLFWAPI void glfwSetWindowIcon(GLFWwindow *handle,
+                               int count, const GLFWimage *images)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
     assert(count >= 0);
     assert(count == 0 || images != NULL);
@@ -538,9 +552,9 @@ GLFWAPI void glfwSetWindowIcon(GLFWwindow* handle,
     _glfwPlatformSetWindowIcon(window, count, images);
 }
 
-GLFWAPI void glfwGetWindowPos(GLFWwindow* handle, int* xpos, int* ypos)
+GLFWAPI void glfwGetWindowPos(GLFWwindow *handle, int *xpos, int *ypos)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     if (xpos)
@@ -552,9 +566,9 @@ GLFWAPI void glfwGetWindowPos(GLFWwindow* handle, int* xpos, int* ypos)
     _glfwPlatformGetWindowPos(window, xpos, ypos);
 }
 
-GLFWAPI void glfwSetWindowPos(GLFWwindow* handle, int xpos, int ypos)
+GLFWAPI void glfwSetWindowPos(GLFWwindow *handle, int xpos, int ypos)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -565,9 +579,9 @@ GLFWAPI void glfwSetWindowPos(GLFWwindow* handle, int xpos, int ypos)
     _glfwPlatformSetWindowPos(window, xpos, ypos);
 }
 
-GLFWAPI void glfwGetWindowSize(GLFWwindow* handle, int* width, int* height)
+GLFWAPI void glfwGetWindowSize(GLFWwindow *handle, int *width, int *height)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     if (width)
@@ -579,26 +593,26 @@ GLFWAPI void glfwGetWindowSize(GLFWwindow* handle, int* width, int* height)
     _glfwPlatformGetWindowSize(window, width, height);
 }
 
-GLFWAPI void glfwSetWindowSize(GLFWwindow* handle, int width, int height)
+GLFWAPI void glfwSetWindowSize(GLFWwindow *handle, int width, int height)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
     assert(width >= 0);
     assert(height >= 0);
 
     _GLFW_REQUIRE_INIT();
 
-    window->videoMode.width  = width;
+    window->videoMode.width = width;
     window->videoMode.height = height;
 
     _glfwPlatformSetWindowSize(window, width, height);
 }
 
-GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* handle,
+GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow *handle,
                                      int minwidth, int minheight,
                                      int maxwidth, int maxheight)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -626,9 +640,9 @@ GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* handle,
         }
     }
 
-    window->minwidth  = minwidth;
+    window->minwidth = minwidth;
     window->minheight = minheight;
-    window->maxwidth  = maxwidth;
+    window->maxwidth = maxwidth;
     window->maxheight = maxheight;
 
     if (window->monitor || !window->resizable)
@@ -639,9 +653,9 @@ GLFWAPI void glfwSetWindowSizeLimits(GLFWwindow* handle,
                                      maxwidth, maxheight);
 }
 
-GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow* handle, int numer, int denom)
+GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow *handle, int numer, int denom)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
     assert(numer != 0);
     assert(denom != 0);
@@ -668,9 +682,9 @@ GLFWAPI void glfwSetWindowAspectRatio(GLFWwindow* handle, int numer, int denom)
     _glfwPlatformSetWindowAspectRatio(window, numer, denom);
 }
 
-GLFWAPI void glfwGetFramebufferSize(GLFWwindow* handle, int* width, int* height)
+GLFWAPI void glfwGetFramebufferSize(GLFWwindow *handle, int *width, int *height)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     if (width)
@@ -682,11 +696,11 @@ GLFWAPI void glfwGetFramebufferSize(GLFWwindow* handle, int* width, int* height)
     _glfwPlatformGetFramebufferSize(window, width, height);
 }
 
-GLFWAPI void glfwGetWindowFrameSize(GLFWwindow* handle,
-                                    int* left, int* top,
-                                    int* right, int* bottom)
+GLFWAPI void glfwGetWindowFrameSize(GLFWwindow *handle,
+                                    int *left, int *top,
+                                    int *right, int *bottom)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     if (left)
@@ -702,10 +716,10 @@ GLFWAPI void glfwGetWindowFrameSize(GLFWwindow* handle,
     _glfwPlatformGetWindowFrameSize(window, left, top, right, bottom);
 }
 
-GLFWAPI void glfwGetWindowContentScale(GLFWwindow* handle,
-                                       float* xscale, float* yscale)
+GLFWAPI void glfwGetWindowContentScale(GLFWwindow *handle,
+                                       float *xscale, float *yscale)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     if (xscale)
@@ -717,18 +731,18 @@ GLFWAPI void glfwGetWindowContentScale(GLFWwindow* handle,
     _glfwPlatformGetWindowContentScale(window, xscale, yscale);
 }
 
-GLFWAPI float glfwGetWindowOpacity(GLFWwindow* handle)
+GLFWAPI float glfwGetWindowOpacity(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(1.f);
     return _glfwPlatformGetWindowOpacity(window);
 }
 
-GLFWAPI void glfwSetWindowOpacity(GLFWwindow* handle, float opacity)
+GLFWAPI void glfwSetWindowOpacity(GLFWwindow *handle, float opacity)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
     assert(opacity == opacity);
     assert(opacity >= 0.f);
@@ -745,27 +759,27 @@ GLFWAPI void glfwSetWindowOpacity(GLFWwindow* handle, float opacity)
     _glfwPlatformSetWindowOpacity(window, opacity);
 }
 
-GLFWAPI void glfwIconifyWindow(GLFWwindow* handle)
+GLFWAPI void glfwIconifyWindow(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
     _glfwPlatformIconifyWindow(window);
 }
 
-GLFWAPI void glfwRestoreWindow(GLFWwindow* handle)
+GLFWAPI void glfwRestoreWindow(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
     _glfwPlatformRestoreWindow(window);
 }
 
-GLFWAPI void glfwMaximizeWindow(GLFWwindow* handle)
+GLFWAPI void glfwMaximizeWindow(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -776,9 +790,9 @@ GLFWAPI void glfwMaximizeWindow(GLFWwindow* handle)
     _glfwPlatformMaximizeWindow(window);
 }
 
-GLFWAPI void glfwShowWindow(GLFWwindow* handle)
+GLFWAPI void glfwShowWindow(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -792,9 +806,9 @@ GLFWAPI void glfwShowWindow(GLFWwindow* handle)
         _glfwPlatformFocusWindow(window);
 }
 
-GLFWAPI void glfwRequestWindowAttention(GLFWwindow* handle)
+GLFWAPI void glfwRequestWindowAttention(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -802,9 +816,9 @@ GLFWAPI void glfwRequestWindowAttention(GLFWwindow* handle)
     _glfwPlatformRequestWindowAttention(window);
 }
 
-GLFWAPI void glfwHideWindow(GLFWwindow* handle)
+GLFWAPI void glfwHideWindow(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -815,9 +829,9 @@ GLFWAPI void glfwHideWindow(GLFWwindow* handle)
     _glfwPlatformHideWindow(window);
 }
 
-GLFWAPI void glfwFocusWindow(GLFWwindow* handle)
+GLFWAPI void glfwFocusWindow(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -825,72 +839,72 @@ GLFWAPI void glfwFocusWindow(GLFWwindow* handle)
     _glfwPlatformFocusWindow(window);
 }
 
-GLFWAPI int glfwGetWindowAttrib(GLFWwindow* handle, int attrib)
+GLFWAPI int glfwGetWindowAttrib(GLFWwindow *handle, int attrib)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(0);
 
     switch (attrib)
     {
-        case GLFW_FOCUSED:
-            return _glfwPlatformWindowFocused(window);
-        case GLFW_ICONIFIED:
-            return _glfwPlatformWindowIconified(window);
-        case GLFW_VISIBLE:
-            return _glfwPlatformWindowVisible(window);
-        case GLFW_MAXIMIZED:
-            return _glfwPlatformWindowMaximized(window);
-        case GLFW_HOVERED:
-            return _glfwPlatformWindowHovered(window);
-        case GLFW_FOCUS_ON_SHOW:
-            return window->focusOnShow;
-        case GLFW_MOUSE_PASSTHROUGH:
-            return window->mousePassthrough;
-        case GLFW_TRANSPARENT_FRAMEBUFFER:
-            return _glfwPlatformFramebufferTransparent(window);
-        case GLFW_RESIZABLE:
-            return window->resizable;
-        case GLFW_DECORATED:
-            return window->decorated;
-        case GLFW_FLOATING:
-            return window->floating;
-        case GLFW_AUTO_ICONIFY:
-            return window->autoIconify;
-        case GLFW_DOUBLEBUFFER:
-            return window->doublebuffer;
-        case GLFW_CLIENT_API:
-            return window->context.client;
-        case GLFW_CONTEXT_CREATION_API:
-            return window->context.source;
-        case GLFW_CONTEXT_VERSION_MAJOR:
-            return window->context.major;
-        case GLFW_CONTEXT_VERSION_MINOR:
-            return window->context.minor;
-        case GLFW_CONTEXT_REVISION:
-            return window->context.revision;
-        case GLFW_CONTEXT_ROBUSTNESS:
-            return window->context.robustness;
-        case GLFW_OPENGL_FORWARD_COMPAT:
-            return window->context.forward;
-        case GLFW_CONTEXT_DEBUG:
-            return window->context.debug;
-        case GLFW_OPENGL_PROFILE:
-            return window->context.profile;
-        case GLFW_CONTEXT_RELEASE_BEHAVIOR:
-            return window->context.release;
-        case GLFW_CONTEXT_NO_ERROR:
-            return window->context.noerror;
+    case GLFW_FOCUSED:
+        return _glfwPlatformWindowFocused(window);
+    case GLFW_ICONIFIED:
+        return _glfwPlatformWindowIconified(window);
+    case GLFW_VISIBLE:
+        return _glfwPlatformWindowVisible(window);
+    case GLFW_MAXIMIZED:
+        return _glfwPlatformWindowMaximized(window);
+    case GLFW_HOVERED:
+        return _glfwPlatformWindowHovered(window);
+    case GLFW_FOCUS_ON_SHOW:
+        return window->focusOnShow;
+    case GLFW_MOUSE_PASSTHROUGH:
+        return window->mousePassthrough;
+    case GLFW_TRANSPARENT_FRAMEBUFFER:
+        return _glfwPlatformFramebufferTransparent(window);
+    case GLFW_RESIZABLE:
+        return window->resizable;
+    case GLFW_DECORATED:
+        return window->decorated;
+    case GLFW_FLOATING:
+        return window->floating;
+    case GLFW_AUTO_ICONIFY:
+        return window->autoIconify;
+    case GLFW_DOUBLEBUFFER:
+        return window->doublebuffer;
+    case GLFW_CLIENT_API:
+        return window->context.client;
+    case GLFW_CONTEXT_CREATION_API:
+        return window->context.source;
+    case GLFW_CONTEXT_VERSION_MAJOR:
+        return window->context.major;
+    case GLFW_CONTEXT_VERSION_MINOR:
+        return window->context.minor;
+    case GLFW_CONTEXT_REVISION:
+        return window->context.revision;
+    case GLFW_CONTEXT_ROBUSTNESS:
+        return window->context.robustness;
+    case GLFW_OPENGL_FORWARD_COMPAT:
+        return window->context.forward;
+    case GLFW_CONTEXT_DEBUG:
+        return window->context.debug;
+    case GLFW_OPENGL_PROFILE:
+        return window->context.profile;
+    case GLFW_CONTEXT_RELEASE_BEHAVIOR:
+        return window->context.release;
+    case GLFW_CONTEXT_NO_ERROR:
+        return window->context.noerror;
     }
 
     _glfwInputError(GLFW_INVALID_ENUM, "Invalid window attribute 0x%08X", attrib);
     return 0;
 }
 
-GLFWAPI void glfwSetWindowAttrib(GLFWwindow* handle, int attrib, int value)
+GLFWAPI void glfwSetWindowAttrib(GLFWwindow *handle, int attrib, int value)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
@@ -928,23 +942,23 @@ GLFWAPI void glfwSetWindowAttrib(GLFWwindow* handle, int attrib, int value)
         _glfwInputError(GLFW_INVALID_ENUM, "Invalid window attribute 0x%08X", attrib);
 }
 
-GLFWAPI GLFWmonitor* glfwGetWindowMonitor(GLFWwindow* handle)
+GLFWAPI GLFWmonitor *glfwGetWindowMonitor(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
-    return (GLFWmonitor*) window->monitor;
+    return (GLFWmonitor *)window->monitor;
 }
 
-GLFWAPI void glfwSetWindowMonitor(GLFWwindow* wh,
-                                  GLFWmonitor* mh,
+GLFWAPI void glfwSetWindowMonitor(GLFWwindow *wh,
+                                  GLFWmonitor *mh,
                                   int xpos, int ypos,
                                   int width, int height,
                                   int refreshRate)
 {
-    _GLFWwindow* window = (_GLFWwindow*) wh;
-    _GLFWmonitor* monitor = (_GLFWmonitor*) mh;
+    _GLFWwindow *window = (_GLFWwindow *)wh;
+    _GLFWmonitor *monitor = (_GLFWmonitor *)mh;
     assert(window != NULL);
     assert(width >= 0);
     assert(height >= 0);
@@ -967,8 +981,8 @@ GLFWAPI void glfwSetWindowMonitor(GLFWwindow* wh,
         return;
     }
 
-    window->videoMode.width       = width;
-    window->videoMode.height      = height;
+    window->videoMode.width = width;
+    window->videoMode.height = height;
     window->videoMode.refreshRate = refreshRate;
 
     _glfwPlatformSetWindowMonitor(window, monitor,
@@ -976,28 +990,28 @@ GLFWAPI void glfwSetWindowMonitor(GLFWwindow* wh,
                                   refreshRate);
 }
 
-GLFWAPI void glfwSetWindowUserPointer(GLFWwindow* handle, void* pointer)
+GLFWAPI void glfwSetWindowUserPointer(GLFWwindow *handle, void *pointer)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT();
     window->userPointer = pointer;
 }
 
-GLFWAPI void* glfwGetWindowUserPointer(GLFWwindow* handle)
+GLFWAPI void *glfwGetWindowUserPointer(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     return window->userPointer;
 }
 
-GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow *handle,
                                                   GLFWwindowposfun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1005,10 +1019,10 @@ GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* handle,
     return cbfun;
 }
 
-GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow *handle,
                                                     GLFWwindowsizefun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1016,10 +1030,10 @@ GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* handle,
     return cbfun;
 }
 
-GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow *handle,
                                                       GLFWwindowclosefun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1027,10 +1041,10 @@ GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* handle,
     return cbfun;
 }
 
-GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow *handle,
                                                           GLFWwindowrefreshfun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1038,10 +1052,10 @@ GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* handle,
     return cbfun;
 }
 
-GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow *handle,
                                                       GLFWwindowfocusfun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1049,10 +1063,10 @@ GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* handle,
     return cbfun;
 }
 
-GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow *handle,
                                                           GLFWwindowiconifyfun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1060,10 +1074,10 @@ GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* handle,
     return cbfun;
 }
 
-GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow *handle,
                                                             GLFWwindowmaximizefun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1071,10 +1085,10 @@ GLFWAPI GLFWwindowmaximizefun glfwSetWindowMaximizeCallback(GLFWwindow* handle,
     return cbfun;
 }
 
-GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* handle,
+GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow *handle,
                                                               GLFWframebuffersizefun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1082,10 +1096,10 @@ GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* handle
     return cbfun;
 }
 
-GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(GLFWwindow* handle,
+GLFWAPI GLFWwindowcontentscalefun glfwSetWindowContentScaleCallback(GLFWwindow *handle,
                                                                     GLFWwindowcontentscalefun cbfun)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     assert(window != NULL);
 
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
@@ -1126,4 +1140,3 @@ GLFWAPI void glfwPostEmptyEvent(void)
     _GLFW_REQUIRE_INIT();
     _glfwPlatformPostEmptyEvent();
 }
-

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -42,26 +42,25 @@
 #include <assert.h>
 
 // Action for EWMH client messages
-#define _NET_WM_STATE_REMOVE        0
-#define _NET_WM_STATE_ADD           1
-#define _NET_WM_STATE_TOGGLE        2
+#define _NET_WM_STATE_REMOVE 0
+#define _NET_WM_STATE_ADD 1
+#define _NET_WM_STATE_TOGGLE 2
 
 // Additional mouse button names for XButtonEvent
-#define Button6            6
-#define Button7            7
+#define Button6 6
+#define Button7 7
 
 // Motif WM hints flags
-#define MWM_HINTS_DECORATIONS   2
-#define MWM_DECOR_ALL           1
+#define MWM_HINTS_DECORATIONS 2
+#define MWM_DECOR_ALL 1
 
 #define _GLFW_XDND_VERSION 5
-
 
 // Wait for data to arrive using select
 // This avoids blocking other threads via the per-display Xlib lock that also
 // covers GLX functions
 //
-static GLFWbool waitForEvent(double* timeout)
+static GLFWbool waitForEvent(double *timeout)
 {
     fd_set fds;
     const int fd = ConnectionNumber(_glfw.x11.display);
@@ -82,16 +81,16 @@ static GLFWbool waitForEvent(double* timeout)
 
         if (timeout)
         {
-            const long seconds = (long) *timeout;
-            const long microseconds = (long) ((*timeout - seconds) * 1e6);
-            struct timeval tv = { seconds, microseconds };
+            const long seconds = (long)*timeout;
+            const long microseconds = (long)((*timeout - seconds) * 1e6);
+            struct timeval tv = {seconds, microseconds};
             const uint64_t base = _glfwPlatformGetTimerValue();
 
             const int result = select(count, &fds, NULL, NULL, &tv);
             const int error = errno;
 
             *timeout -= (_glfwPlatformGetTimerValue() - base) /
-                (double) _glfwPlatformGetTimerFrequency();
+                        (double)_glfwPlatformGetTimerFrequency();
 
             if (result > 0)
                 return GLFW_TRUE;
@@ -106,7 +105,7 @@ static GLFWbool waitForEvent(double* timeout)
 // Waits until a VisibilityNotify event arrives for the specified window or the
 // timeout period elapses (ICCCM section 4.2.2)
 //
-static GLFWbool waitForVisibilityNotify(_GLFWwindow* window)
+static GLFWbool waitForVisibilityNotify(_GLFWwindow *window)
 {
     XEvent dummy;
     double timeout = 0.1;
@@ -125,10 +124,11 @@ static GLFWbool waitForVisibilityNotify(_GLFWwindow* window)
 
 // Returns whether the window is iconified
 //
-static int getWindowState(_GLFWwindow* window)
+static int getWindowState(_GLFWwindow *window)
 {
     int result = WithdrawnState;
-    struct {
+    struct
+    {
         CARD32 state;
         Window icon;
     } *state = NULL;
@@ -136,7 +136,7 @@ static int getWindowState(_GLFWwindow* window)
     if (_glfwGetWindowPropertyX11(window->x11.handle,
                                   _glfw.x11.WM_STATE,
                                   _glfw.x11.WM_STATE,
-                                  (unsigned char**) &state) >= 2)
+                                  (unsigned char **)&state) >= 2)
     {
         result = state->state;
     }
@@ -149,7 +149,7 @@ static int getWindowState(_GLFWwindow* window)
 
 // Returns whether the event is a selection event
 //
-static Bool isSelectionEvent(Display* display, XEvent* event, XPointer pointer)
+static Bool isSelectionEvent(Display *display, XEvent *event, XPointer pointer)
 {
     if (event->xany.window != _glfw.x11.helperWindowHandle)
         return False;
@@ -161,9 +161,9 @@ static Bool isSelectionEvent(Display* display, XEvent* event, XPointer pointer)
 
 // Returns whether it is a _NET_FRAME_EXTENTS event for the specified window
 //
-static Bool isFrameExtentsEvent(Display* display, XEvent* event, XPointer pointer)
+static Bool isFrameExtentsEvent(Display *display, XEvent *event, XPointer pointer)
 {
-    _GLFWwindow* window = (_GLFWwindow*) pointer;
+    _GLFWwindow *window = (_GLFWwindow *)pointer;
     return event->type == PropertyNotify &&
            event->xproperty.state == PropertyNewValue &&
            event->xproperty.window == window->x11.handle &&
@@ -172,9 +172,9 @@ static Bool isFrameExtentsEvent(Display* display, XEvent* event, XPointer pointe
 
 // Returns whether it is a property event for the specified selection transfer
 //
-static Bool isSelPropNewValueNotify(Display* display, XEvent* event, XPointer pointer)
+static Bool isSelPropNewValueNotify(Display *display, XEvent *event, XPointer pointer)
 {
-    XEvent* notification = (XEvent*) pointer;
+    XEvent *notification = (XEvent *)pointer;
     return event->type == PropertyNotify &&
            event->xproperty.state == PropertyNewValue &&
            event->xproperty.window == notification->xselection.requestor &&
@@ -216,10 +216,10 @@ static int translateKey(int scancode)
 
 // Sends an EWMH or ICCCM event to the window manager
 //
-static void sendEventToWM(_GLFWwindow* window, Atom type,
+static void sendEventToWM(_GLFWwindow *window, Atom type,
                           long a, long b, long c, long d, long e)
 {
-    XEvent event = { ClientMessage };
+    XEvent event = {ClientMessage};
     event.xclient.window = window->x11.handle;
     event.xclient.format = 32; // Data is 32-bit longs
     event.xclient.message_type = type;
@@ -237,9 +237,9 @@ static void sendEventToWM(_GLFWwindow* window, Atom type,
 
 // Updates the normal hints according to the window settings
 //
-static void updateNormalHints(_GLFWwindow* window, int width, int height)
+static void updateNormalHints(_GLFWwindow *window, int width, int height)
 {
-    XSizeHints* hints = XAllocSizeHints();
+    XSizeHints *hints = XAllocSizeHints();
 
     if (!window->monitor)
     {
@@ -272,7 +272,7 @@ static void updateNormalHints(_GLFWwindow* window, int width, int height)
         else
         {
             hints->flags |= (PMinSize | PMaxSize);
-            hints->min_width  = hints->max_width  = width;
+            hints->min_width = hints->max_width = width;
             hints->min_height = hints->max_height = height;
         }
     }
@@ -286,7 +286,7 @@ static void updateNormalHints(_GLFWwindow* window, int width, int height)
 
 // Updates the full screen status of the window
 //
-static void updateWindowMode(_GLFWwindow* window)
+static void updateWindowMode(_GLFWwindow *window)
 {
     if (window->monitor)
     {
@@ -335,9 +335,9 @@ static void updateWindowMode(_GLFWwindow* window)
         {
             const unsigned long value = 1;
 
-            XChangeProperty(_glfw.x11.display,  window->x11.handle,
+            XChangeProperty(_glfw.x11.display, window->x11.handle,
                             _glfw.x11.NET_WM_BYPASS_COMPOSITOR, XA_CARDINAL, 32,
-                            PropModeReplace, (unsigned char*) &value, 1);
+                            PropModeReplace, (unsigned char *)&value, 1);
         }
     }
     else
@@ -381,11 +381,11 @@ static void updateWindowMode(_GLFWwindow* window)
 // Splits and translates a text/uri-list into separate file paths
 // NOTE: This function destroys the provided string
 //
-static char** parseUriList(char* text, int* count)
+static char **parseUriList(char *text, int *count)
 {
-    const char* prefix = "file://";
-    char** paths = NULL;
-    char* line;
+    const char *prefix = "file://";
+    char **paths = NULL;
+    char *line;
 
     *count = 0;
 
@@ -406,15 +406,15 @@ static char** parseUriList(char* text, int* count)
 
         (*count)++;
 
-        char* path = _glfw_calloc(strlen(line) + 1, 1);
-        paths = _glfw_realloc(paths, *count * sizeof(char*));
+        char *path = _glfw_calloc(strlen(line) + 1, 1);
+        paths = _glfw_realloc(paths, *count * sizeof(char *));
         paths[*count - 1] = path;
 
         while (*line)
         {
             if (line[0] == '%' && line[1] && line[2])
             {
-                const char digits[3] = { line[1], line[2], '\0' };
+                const char digits[3] = {line[1], line[2], '\0'};
                 *path = strtol(digits, NULL, 16);
                 line += 2;
             }
@@ -432,12 +432,12 @@ static char** parseUriList(char* text, int* count)
 // Encode a Unicode code point to a UTF-8 stream
 // Based on cutef8 by Jeff Bezanson (Public Domain)
 //
-static size_t encodeUTF8(char* s, unsigned int ch)
+static size_t encodeUTF8(char *s, unsigned int ch)
 {
     size_t count = 0;
 
     if (ch < 0x80)
-        s[count++] = (char) ch;
+        s[count++] = (char)ch;
     else if (ch < 0x800)
     {
         s[count++] = (ch >> 6) | 0xc0;
@@ -463,18 +463,17 @@ static size_t encodeUTF8(char* s, unsigned int ch)
 // Decode a Unicode code point from a UTF-8 stream
 // Based on cutef8 by Jeff Bezanson (Public Domain)
 //
-static unsigned int decodeUTF8(const char** s)
+static unsigned int decodeUTF8(const char **s)
 {
     unsigned int ch = 0, count = 0;
     static const unsigned int offsets[] =
-    {
-        0x00000000u, 0x00003080u, 0x000e2080u,
-        0x03c82080u, 0xfa082080u, 0x82082080u
-    };
+        {
+            0x00000000u, 0x00003080u, 0x000e2080u,
+            0x03c82080u, 0xfa082080u, 0x82082080u};
 
     do
     {
-        ch = (ch << 6) + (unsigned char) **s;
+        ch = (ch << 6) + (unsigned char)**s;
         (*s)++;
         count++;
     } while ((**s & 0xc0) == 0x80);
@@ -485,18 +484,18 @@ static unsigned int decodeUTF8(const char** s)
 
 // Convert the specified Latin-1 string to UTF-8
 //
-static char* convertLatin1toUTF8(const char* source)
+static char *convertLatin1toUTF8(const char *source)
 {
     size_t size = 1;
-    const char* sp;
+    const char *sp;
 
-    for (sp = source;  *sp;  sp++)
+    for (sp = source; *sp; sp++)
         size += (*sp & 0x80) ? 2 : 1;
 
-    char* target = _glfw_calloc(size, 1);
-    char* tp = target;
+    char *target = _glfw_calloc(size, 1);
+    char *tp = target;
 
-    for (sp = source;  *sp;  sp++)
+    for (sp = source; *sp; sp++)
         tp += encodeUTF8(tp, *sp);
 
     return target;
@@ -504,7 +503,7 @@ static char* convertLatin1toUTF8(const char* source)
 
 // Updates the cursor image according to its cursor mode
 //
-static void updateCursorImage(_GLFWwindow* window)
+static void updateCursorImage(_GLFWwindow *window)
 {
     if (window->cursorMode == GLFW_CURSOR_NORMAL)
     {
@@ -525,10 +524,10 @@ static void updateCursorImage(_GLFWwindow* window)
 
 // Enable XI2 raw mouse motion events
 //
-static void enableRawMouseMotion(_GLFWwindow* window)
+static void enableRawMouseMotion(_GLFWwindow *window)
 {
     XIEventMask em;
-    unsigned char mask[XIMaskLen(XI_RawMotion)] = { 0 };
+    unsigned char mask[XIMaskLen(XI_RawMotion)] = {0};
 
     em.deviceid = XIAllMasterDevices;
     em.mask_len = sizeof(mask);
@@ -540,10 +539,10 @@ static void enableRawMouseMotion(_GLFWwindow* window)
 
 // Disable XI2 raw mouse motion events
 //
-static void disableRawMouseMotion(_GLFWwindow* window)
+static void disableRawMouseMotion(_GLFWwindow *window)
 {
     XIEventMask em;
-    unsigned char mask[] = { 0 };
+    unsigned char mask[] = {0};
 
     em.deviceid = XIAllMasterDevices;
     em.mask_len = sizeof(mask);
@@ -554,7 +553,7 @@ static void disableRawMouseMotion(_GLFWwindow* window)
 
 // Apply disabled cursor mode to a focused window
 //
-static void disableCursor(_GLFWwindow* window)
+static void disableCursor(_GLFWwindow *window)
 {
     if (window->rawMouseMotion)
         enableRawMouseMotion(window);
@@ -575,7 +574,7 @@ static void disableCursor(_GLFWwindow* window)
 
 // Exit disabled cursor mode for the specified window
 //
-static void enableCursor(_GLFWwindow* window)
+static void enableCursor(_GLFWwindow *window)
 {
     if (window->rawMouseMotion)
         disableRawMouseMotion(window);
@@ -592,15 +591,15 @@ static void enableCursor(_GLFWwindow* window)
 //
 static void inputContextDestroyCallback(XIC ic, XPointer clientData, XPointer callData)
 {
-    _GLFWwindow* window = (_GLFWwindow*) clientData;
+    _GLFWwindow *window = (_GLFWwindow *)clientData;
     window->x11.ic = NULL;
 }
 
 // Create the X11 window (and its colormap)
 //
-static GLFWbool createNativeWindow(_GLFWwindow* window,
-                                   const _GLFWwndconfig* wndconfig,
-                                   Visual* visual, int depth)
+static GLFWbool createNativeWindow(_GLFWwindow *window,
+                                   const _GLFWwndconfig *wndconfig,
+                                   Visual *visual, int depth)
 {
     int width = wndconfig->width;
     int height = wndconfig->height;
@@ -619,7 +618,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
 
     window->x11.transparent = _glfwIsVisualTransparentX11(visual);
 
-    XSetWindowAttributes wa = { 0 };
+    XSetWindowAttributes wa = {0};
     wa.colormap = window->x11.colormap;
     wa.event_mask = StructureNotifyMask | KeyPressMask | KeyReleaseMask |
                     PointerMotionMask | ButtonPressMask | ButtonReleaseMask |
@@ -629,14 +628,14 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
     _glfwGrabErrorHandlerX11();
 
     window->x11.parent = (wndconfig->nativeParent
-                          ? (Window)wndconfig->nativeParent
-                          : _glfw.x11.root);
+                              ? (Window)wndconfig->nativeParent
+                              : _glfw.x11.root);
     window->x11.handle = XCreateWindow(_glfw.x11.display,
                                        window->x11.parent,
-                                       0, 0,   // Position
+                                       0, 0, // Position
                                        width, height,
-                                       0,      // Border width
-                                       depth,  // Color depth
+                                       0,     // Border width
+                                       depth, // Color depth
                                        InputOutput,
                                        visual,
                                        CWBorderPixel | CWColormap | CWEventMask,
@@ -656,7 +655,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
         XSaveContext(_glfw.x11.display,
                      window->x11.handle,
                      _glfw.x11.context,
-                     (XPointer) window);
+                     (XPointer)window);
 
         if (!wndconfig->decorated)
             _glfwPlatformSetWindowDecorated(window, GLFW_FALSE);
@@ -687,17 +686,16 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
             {
                 XChangeProperty(_glfw.x11.display, window->x11.handle,
                                 _glfw.x11.NET_WM_STATE, XA_ATOM, 32,
-                                PropModeReplace, (unsigned char*) states, count);
+                                PropModeReplace, (unsigned char *)states, count);
             }
         }
 
         // Declare the WM protocols supported by GLFW
         {
             Atom protocols[] =
-                    {
-                            _glfw.x11.WM_DELETE_WINDOW,
-                            _glfw.x11.NET_WM_PING
-                    };
+                {
+                    _glfw.x11.WM_DELETE_WINDOW,
+                    _glfw.x11.NET_WM_PING};
 
             XSetWMProtocols(_glfw.x11.display, window->x11.handle,
                             protocols, sizeof(protocols) / sizeof(Atom));
@@ -707,23 +705,101 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
         {
             const long pid = getpid();
 
-            XChangeProperty(_glfw.x11.display,  window->x11.handle,
+            XChangeProperty(_glfw.x11.display, window->x11.handle,
                             _glfw.x11.NET_WM_PID, XA_CARDINAL, 32,
                             PropModeReplace,
-                            (unsigned char*) &pid, 1);
+                            (unsigned char *)&pid, 1);
         }
 
         if (_glfw.x11.NET_WM_WINDOW_TYPE && _glfw.x11.NET_WM_WINDOW_TYPE_NORMAL)
         {
             Atom type = _glfw.x11.NET_WM_WINDOW_TYPE_NORMAL;
-            XChangeProperty(_glfw.x11.display,  window->x11.handle,
+            XChangeProperty(_glfw.x11.display, window->x11.handle,
                             _glfw.x11.NET_WM_WINDOW_TYPE, XA_ATOM, 32,
-                            PropModeReplace, (unsigned char*) &type, 1);
+                            PropModeReplace, (unsigned char *)&type, 1);
+        }
+
+        if (wndconfig->isDesktopWindow)
+        {
+            Atom type = XInternAtom(_glfw.x11.display, "_NET_WM_WINDOW_TYPE_DESKTOP", False);
+            XChangeProperty(_glfw.x11.display, window->x11.handle,
+                            _glfw.x11.NET_WM_WINDOW_TYPE, XA_ATOM, 32,
+                            PropModeReplace, (unsigned char *)&type, 1);
+        }
+
+        if (wndconfig->sticky)
+        {
+            Atom xa = XInternAtom(_glfw.x11.display, "_NET_WM_DESKTOP", False);
+            if (xa != None)
+            {
+                CARD32 xa_prop = 0xFFFFFFFF;
+                XChangeProperty(_glfw.x11.display, window->x11.handle, xa, XA_CARDINAL, 32,
+                                PropModeAppend,
+                                (unsigned char *)&xa_prop, 1);
+            }
+
+            xa = XInternAtom(_glfw.x11.display, "_NET_WM_STATE", False);
+            if (xa != None)
+            {
+                Atom xa_prop = XInternAtom(_glfw.x11.display, "_NET_WM_STATE_STICKY", False);
+                XChangeProperty(_glfw.x11.display, window->x11.handle, xa, XA_ATOM, 32,
+                                PropModeAppend,
+                                (unsigned char *)&xa_prop, 1);
+            }
+        }
+
+        if (wndconfig->below)
+        {
+            Atom xa = XInternAtom(_glfw.x11.display, "_WIN_LAYER", False);
+            if (xa != None)
+            {
+                long prop = 0;
+
+                XChangeProperty(_glfw.x11.display, window->x11.handle, xa, XA_CARDINAL, 32,
+                                PropModeAppend,
+                                (unsigned char *)&prop, 1);
+            }
+
+            xa = XInternAtom(_glfw.x11.display, "_NET_WM_STATE", False);
+            if (xa != None)
+            {
+                Atom xa_prop = XInternAtom(_glfw.x11.display, "_NET_WM_STATE_BELOW", False);
+
+                XChangeProperty(_glfw.x11.display, window->x11.handle, xa, XA_ATOM, 32,
+                                PropModeAppend,
+                                (unsigned char *)&xa_prop, 1);
+            }
+        }
+
+        if (wndconfig->skipTaskbar)
+        {
+            Atom xa = XInternAtom(_glfw.x11.display, "_NET_WM_STATE", False);
+            if (xa != None)
+            {
+                Atom xa_prop = XInternAtom(_glfw.x11.display, "_NET_WM_STATE_SKIP_TASKBAR", False);
+
+                XChangeProperty(_glfw.x11.display, window->x11.handle, xa, XA_ATOM, 32,
+                                PropModeAppend,
+                                (unsigned char *)&xa_prop, 1);
+            }
+        }
+
+        if (wndconfig->skipPager)
+        {
+            Atom xa = XInternAtom(_glfw.x11.display, "_NET_WM_STATE", False);
+            if (xa != None)
+            {
+                Atom xa_prop = XInternAtom(_glfw.x11.display, "_NET_WM_STATE_SKIP_PAGER", False);
+
+                XChangeProperty(_glfw.x11.display, window->x11.handle, xa, XA_ATOM, 32,
+                                PropModeAppend,
+                                (unsigned char *)&xa_prop, 1);
+            }
         }
 
         // Set ICCCM WM_HINTS property
         {
-            XWMHints* hints = XAllocWMHints();
+            XWMHints *hints = XAllocWMHints();
             if (!hints)
             {
                 _glfwInputError(GLFW_OUT_OF_MEMORY,
@@ -742,28 +818,28 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
 
         // Set ICCCM WM_CLASS property
         {
-            XClassHint* hint = XAllocClassHint();
+            XClassHint *hint = XAllocClassHint();
 
             if (strlen(wndconfig->x11.instanceName) &&
                 strlen(wndconfig->x11.className))
             {
-                hint->res_name = (char*) wndconfig->x11.instanceName;
-                hint->res_class = (char*) wndconfig->x11.className;
+                hint->res_name = (char *)wndconfig->x11.instanceName;
+                hint->res_class = (char *)wndconfig->x11.className;
             }
             else
             {
-                const char* resourceName = getenv("RESOURCE_NAME");
+                const char *resourceName = getenv("RESOURCE_NAME");
                 if (resourceName && strlen(resourceName))
-                    hint->res_name = (char*) resourceName;
+                    hint->res_name = (char *)resourceName;
                 else if (strlen(wndconfig->title))
-                    hint->res_name = (char*) wndconfig->title;
+                    hint->res_name = (char *)wndconfig->title;
                 else
-                    hint->res_name = (char*) "glfw-application";
+                    hint->res_name = (char *)"glfw-application";
 
                 if (strlen(wndconfig->title))
-                    hint->res_class = (char*) wndconfig->title;
+                    hint->res_class = (char *)wndconfig->title;
                 else
-                    hint->res_class = (char*) "GLFW-Application";
+                    hint->res_class = (char *)"GLFW-Application";
             }
 
             XSetClassHint(_glfw.x11.display, window->x11.handle, hint);
@@ -775,9 +851,8 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
             const Atom version = _GLFW_XDND_VERSION;
             XChangeProperty(_glfw.x11.display, window->x11.handle,
                             _glfw.x11.XdndAware, XA_ATOM, 32,
-                            PropModeReplace, (unsigned char*) &version, 1);
+                            PropModeReplace, (unsigned char *)&version, 1);
         }
-
 
         _glfwPlatformSetWindowTitle(window, wndconfig->title);
         _glfwPlatformGetWindowPos(window, &window->x11.xpos, &window->x11.ypos);
@@ -792,11 +867,11 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
 
 // Set the specified property to the selection converted to the requested target
 //
-static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
+static Atom writeTargetToProperty(const XSelectionRequestEvent *request)
 {
     int i;
-    char* selectionString = NULL;
-    const Atom formats[] = { _glfw.x11.UTF8_STRING, XA_STRING };
+    char *selectionString = NULL;
+    const Atom formats[] = {_glfw.x11.UTF8_STRING, XA_STRING};
     const int formatCount = sizeof(formats) / sizeof(formats[0]);
 
     if (request->selection == _glfw.x11.PRIMARY)
@@ -815,10 +890,10 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
     {
         // The list of supported targets was requested
 
-        const Atom targets[] = { _glfw.x11.TARGETS,
-                                 _glfw.x11.MULTIPLE,
-                                 _glfw.x11.UTF8_STRING,
-                                 XA_STRING };
+        const Atom targets[] = {_glfw.x11.TARGETS,
+                                _glfw.x11.MULTIPLE,
+                                _glfw.x11.UTF8_STRING,
+                                XA_STRING};
 
         XChangeProperty(_glfw.x11.display,
                         request->requestor,
@@ -826,7 +901,7 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
                         XA_ATOM,
                         32,
                         PropModeReplace,
-                        (unsigned char*) targets,
+                        (unsigned char *)targets,
                         sizeof(targets) / sizeof(targets[0]));
 
         return request->property;
@@ -836,19 +911,19 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
     {
         // Multiple conversions were requested
 
-        Atom* targets;
+        Atom *targets;
         unsigned long i, count;
 
         count = _glfwGetWindowPropertyX11(request->requestor,
                                           request->property,
                                           _glfw.x11.ATOM_PAIR,
-                                          (unsigned char**) &targets);
+                                          (unsigned char **)&targets);
 
-        for (i = 0;  i < count;  i += 2)
+        for (i = 0; i < count; i += 2)
         {
             int j;
 
-            for (j = 0;  j < formatCount;  j++)
+            for (j = 0; j < formatCount; j++)
             {
                 if (targets[i] == formats[j])
                     break;
@@ -862,7 +937,7 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
                                 targets[i],
                                 8,
                                 PropModeReplace,
-                                (unsigned char *) selectionString,
+                                (unsigned char *)selectionString,
                                 strlen(selectionString));
             }
             else
@@ -875,7 +950,7 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
                         _glfw.x11.ATOM_PAIR,
                         32,
                         PropModeReplace,
-                        (unsigned char*) targets,
+                        (unsigned char *)targets,
                         count);
 
         XFree(targets);
@@ -902,7 +977,7 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
 
     // Conversion to a data target was requested
 
-    for (i = 0;  i < formatCount;  i++)
+    for (i = 0; i < formatCount; i++)
     {
         if (request->target == formats[i])
         {
@@ -914,7 +989,7 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
                             request->target,
                             8,
                             PropModeReplace,
-                            (unsigned char *) selectionString,
+                            (unsigned char *)selectionString,
                             strlen(selectionString));
 
             return request->property;
@@ -926,7 +1001,7 @@ static Atom writeTargetToProperty(const XSelectionRequestEvent* request)
     return None;
 }
 
-static void handleSelectionClear(XEvent* event)
+static void handleSelectionClear(XEvent *event)
 {
     if (event->xselectionclear.selection == _glfw.x11.PRIMARY)
     {
@@ -940,11 +1015,11 @@ static void handleSelectionClear(XEvent* event)
     }
 }
 
-static void handleSelectionRequest(XEvent* event)
+static void handleSelectionRequest(XEvent *event)
 {
-    const XSelectionRequestEvent* request = &event->xselectionrequest;
+    const XSelectionRequestEvent *request = &event->xselectionrequest;
 
-    XEvent reply = { SelectionNotify };
+    XEvent reply = {SelectionNotify};
     reply.xselection.property = writeTargetToProperty(request);
     reply.xselection.display = request->display;
     reply.xselection.requestor = request->requestor;
@@ -955,10 +1030,10 @@ static void handleSelectionRequest(XEvent* event)
     XSendEvent(_glfw.x11.display, request->requestor, False, 0, &reply);
 }
 
-static const char* getSelectionString(Atom selection)
+static const char *getSelectionString(Atom selection)
 {
-    char** selectionString = NULL;
-    const Atom targets[] = { _glfw.x11.UTF8_STRING, XA_STRING };
+    char **selectionString = NULL;
+    const Atom targets[] = {_glfw.x11.UTF8_STRING, XA_STRING};
     const size_t targetCount = sizeof(targets) / sizeof(targets[0]);
 
     if (selection == _glfw.x11.PRIMARY)
@@ -977,9 +1052,9 @@ static const char* getSelectionString(Atom selection)
     _glfw_free(*selectionString);
     *selectionString = NULL;
 
-    for (size_t i = 0;  i < targetCount;  i++)
+    for (size_t i = 0; i < targetCount; i++)
     {
-        char* data;
+        char *data;
         Atom actualType;
         int actualFormat;
         unsigned long itemCount, bytesAfter;
@@ -1006,7 +1081,7 @@ static const char* getSelectionString(Atom selection)
         XCheckIfEvent(_glfw.x11.display,
                       &dummy,
                       isSelPropNewValueNotify,
-                      (XPointer) &notification);
+                      (XPointer)&notification);
 
         XGetWindowProperty(_glfw.x11.display,
                            notification.xselection.requestor,
@@ -1019,19 +1094,19 @@ static const char* getSelectionString(Atom selection)
                            &actualFormat,
                            &itemCount,
                            &bytesAfter,
-                           (unsigned char**) &data);
+                           (unsigned char **)&data);
 
         if (actualType == _glfw.x11.INCR)
         {
             size_t size = 1;
-            char* string = NULL;
+            char *string = NULL;
 
             for (;;)
             {
                 while (!XCheckIfEvent(_glfw.x11.display,
                                       &dummy,
                                       isSelPropNewValueNotify,
-                                      (XPointer) &notification))
+                                      (XPointer)&notification))
                 {
                     waitForEvent(NULL);
                 }
@@ -1048,7 +1123,7 @@ static const char* getSelectionString(Atom selection)
                                    &actualFormat,
                                    &itemCount,
                                    &bytesAfter,
-                                   (unsigned char**) &data);
+                                   (unsigned char **)&data);
 
                 if (itemCount)
                 {
@@ -1097,7 +1172,7 @@ static const char* getSelectionString(Atom selection)
 
 // Make the specified window and its video mode active on its monitor
 //
-static void acquireMonitor(_GLFWwindow* window)
+static void acquireMonitor(_GLFWwindow *window)
 {
     if (_glfw.x11.saver.count == 0)
     {
@@ -1136,7 +1211,7 @@ static void acquireMonitor(_GLFWwindow* window)
 
 // Remove the window and restore the original video mode
 //
-static void releaseMonitor(_GLFWwindow* window)
+static void releaseMonitor(_GLFWwindow *window)
 {
     if (window->monitor->window != window)
         return;
@@ -1184,10 +1259,10 @@ static void processEvent(XEvent *event)
     {
         if (event->type == _glfw.x11.xkb.eventBase + XkbEventCode)
         {
-            if (((XkbEvent*) event)->any.xkb_type == XkbStateNotify &&
-                (((XkbEvent*) event)->state.changed & XkbGroupStateMask))
+            if (((XkbEvent *)event)->any.xkb_type == XkbStateNotify &&
+                (((XkbEvent *)event)->state.changed & XkbGroupStateMask))
             {
-                _glfw.x11.xkb.group = ((XkbEvent*) event)->state.group;
+                _glfw.x11.xkb.group = ((XkbEvent *)event)->state.group;
             }
 
             return;
@@ -1198,7 +1273,7 @@ static void processEvent(XEvent *event)
     {
         if (_glfw.x11.xi.available)
         {
-            _GLFWwindow* window = _glfw.x11.disabledCursorWindow;
+            _GLFWwindow *window = _glfw.x11.disabledCursorWindow;
 
             if (window &&
                 window->rawMouseMotion &&
@@ -1206,10 +1281,10 @@ static void processEvent(XEvent *event)
                 XGetEventData(_glfw.x11.display, &event->xcookie) &&
                 event->xcookie.evtype == XI_RawMotion)
             {
-                XIRawEvent* re = event->xcookie.data;
+                XIRawEvent *re = event->xcookie.data;
                 if (re->valuators.mask_len)
                 {
-                    const double* values = re->raw_values;
+                    const double *values = re->raw_values;
                     double xpos = window->virtualCursorPosX;
                     double ypos = window->virtualCursorPosY;
 
@@ -1243,11 +1318,11 @@ static void processEvent(XEvent *event)
         return;
     }
 
-    _GLFWwindow* window = NULL;
+    _GLFWwindow *window = NULL;
     if (XFindContext(_glfw.x11.display,
                      event->xany.window,
                      _glfw.x11.context,
-                     (XPointer*) &window) != 0)
+                     (XPointer *)&window) != 0)
     {
         // This is an event for a window that has already been destroyed
         return;
@@ -1255,600 +1330,599 @@ static void processEvent(XEvent *event)
 
     switch (event->type)
     {
-        case ReparentNotify:
-        {
-            window->x11.parent = event->xreparent.parent;
-            return;
-        }
+    case ReparentNotify:
+    {
+        window->x11.parent = event->xreparent.parent;
+        return;
+    }
 
-        case KeyPress:
-        {
-            const int key = translateKey(keycode);
-            const int mods = translateState(event->xkey.state);
-            const int plain = !(mods & (GLFW_MOD_CONTROL | GLFW_MOD_ALT));
+    case KeyPress:
+    {
+        const int key = translateKey(keycode);
+        const int mods = translateState(event->xkey.state);
+        const int plain = !(mods & (GLFW_MOD_CONTROL | GLFW_MOD_ALT));
 
-            if (window->x11.ic)
+        if (window->x11.ic)
+        {
+            // HACK: Do not report the key press events duplicated by XIM
+            //       Duplicate key releases are filtered out implicitly by
+            //       the GLFW key repeat logic in _glfwInputKey
+            //       A timestamp per key is used to handle simultaneous keys
+            // NOTE: Always allow the first event for each key through
+            //       (the server never sends a timestamp of zero)
+            // NOTE: Timestamp difference is compared to handle wrap-around
+            Time diff = event->xkey.time - window->x11.keyPressTimes[keycode];
+            if (diff == event->xkey.time || (diff > 0 && diff < (1 << 31)))
             {
-                // HACK: Do not report the key press events duplicated by XIM
-                //       Duplicate key releases are filtered out implicitly by
-                //       the GLFW key repeat logic in _glfwInputKey
-                //       A timestamp per key is used to handle simultaneous keys
-                // NOTE: Always allow the first event for each key through
-                //       (the server never sends a timestamp of zero)
-                // NOTE: Timestamp difference is compared to handle wrap-around
-                Time diff = event->xkey.time - window->x11.keyPressTimes[keycode];
-                if (diff == event->xkey.time || (diff > 0 && diff < (1 << 31)))
+                if (keycode)
+                    _glfwInputKey(window, key, keycode, GLFW_PRESS, mods);
+
+                window->x11.keyPressTimes[keycode] = event->xkey.time;
+            }
+
+            if (!filtered)
+            {
+                int count;
+                Status status;
+                char buffer[100];
+                char *chars = buffer;
+
+                count = Xutf8LookupString(window->x11.ic,
+                                          &event->xkey,
+                                          buffer, sizeof(buffer) - 1,
+                                          NULL, &status);
+
+                if (status == XBufferOverflow)
                 {
-                    if (keycode)
-                        _glfwInputKey(window, key, keycode, GLFW_PRESS, mods);
-
-                    window->x11.keyPressTimes[keycode] = event->xkey.time;
-                }
-
-                if (!filtered)
-                {
-                    int count;
-                    Status status;
-                    char buffer[100];
-                    char* chars = buffer;
-
+                    chars = _glfw_calloc(count + 1, 1);
                     count = Xutf8LookupString(window->x11.ic,
                                               &event->xkey,
-                                              buffer, sizeof(buffer) - 1,
+                                              chars, count,
                                               NULL, &status);
-
-                    if (status == XBufferOverflow)
-                    {
-                        chars = _glfw_calloc(count + 1, 1);
-                        count = Xutf8LookupString(window->x11.ic,
-                                                  &event->xkey,
-                                                  chars, count,
-                                                  NULL, &status);
-                    }
-
-                    if (status == XLookupChars || status == XLookupBoth)
-                    {
-                        const char* c = chars;
-                        chars[count] = '\0';
-                        while (c - chars < count)
-                            _glfwInputChar(window, decodeUTF8(&c), mods, plain);
-                    }
-
-                    if (chars != buffer)
-                        _glfw_free(chars);
                 }
+
+                if (status == XLookupChars || status == XLookupBoth)
+                {
+                    const char *c = chars;
+                    chars[count] = '\0';
+                    while (c - chars < count)
+                        _glfwInputChar(window, decodeUTF8(&c), mods, plain);
+                }
+
+                if (chars != buffer)
+                    _glfw_free(chars);
+            }
+        }
+        else
+        {
+            KeySym keysym;
+            XLookupString(&event->xkey, NULL, 0, &keysym, NULL);
+
+            _glfwInputKey(window, key, keycode, GLFW_PRESS, mods);
+
+            const long character = _glfwKeySym2Unicode(keysym);
+            if (character != -1)
+                _glfwInputChar(window, character, mods, plain);
+        }
+
+        return;
+    }
+
+    case KeyRelease:
+    {
+        const int key = translateKey(keycode);
+        const int mods = translateState(event->xkey.state);
+
+        if (!_glfw.x11.xkb.detectable)
+        {
+            // HACK: Key repeat events will arrive as KeyRelease/KeyPress
+            //       pairs with similar or identical time stamps
+            //       The key repeat logic in _glfwInputKey expects only key
+            //       presses to repeat, so detect and discard release events
+            if (XEventsQueued(_glfw.x11.display, QueuedAfterReading))
+            {
+                XEvent next;
+                XPeekEvent(_glfw.x11.display, &next);
+
+                if (next.type == KeyPress &&
+                    next.xkey.window == event->xkey.window &&
+                    next.xkey.keycode == keycode)
+                {
+                    // HACK: The time of repeat events sometimes doesn't
+                    //       match that of the press event, so add an
+                    //       epsilon
+                    //       Toshiyuki Takahashi can press a button
+                    //       16 times per second so it's fairly safe to
+                    //       assume that no human is pressing the key 50
+                    //       times per second (value is ms)
+                    if ((next.xkey.time - event->xkey.time) < 20)
+                    {
+                        // This is very likely a server-generated key repeat
+                        // event, so ignore it
+                        return;
+                    }
+                }
+            }
+        }
+
+        _glfwInputKey(window, key, keycode, GLFW_RELEASE, mods);
+        return;
+    }
+
+    case ButtonPress:
+    {
+        const int mods = translateState(event->xbutton.state);
+
+        if (event->xbutton.button == Button1)
+            _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_PRESS, mods);
+        else if (event->xbutton.button == Button2)
+            _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_MIDDLE, GLFW_PRESS, mods);
+        else if (event->xbutton.button == Button3)
+            _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_RIGHT, GLFW_PRESS, mods);
+
+        // Modern X provides scroll events as mouse button presses
+        else if (event->xbutton.button == Button4)
+            _glfwInputScroll(window, 0.0, 1.0);
+        else if (event->xbutton.button == Button5)
+            _glfwInputScroll(window, 0.0, -1.0);
+        else if (event->xbutton.button == Button6)
+            _glfwInputScroll(window, 1.0, 0.0);
+        else if (event->xbutton.button == Button7)
+            _glfwInputScroll(window, -1.0, 0.0);
+
+        else
+        {
+            // Additional buttons after 7 are treated as regular buttons
+            // We subtract 4 to fill the gap left by scroll input above
+            _glfwInputMouseClick(window,
+                                 event->xbutton.button - Button1 - 4,
+                                 GLFW_PRESS,
+                                 mods);
+        }
+
+        return;
+    }
+
+    case ButtonRelease:
+    {
+        const int mods = translateState(event->xbutton.state);
+
+        if (event->xbutton.button == Button1)
+        {
+            _glfwInputMouseClick(window,
+                                 GLFW_MOUSE_BUTTON_LEFT,
+                                 GLFW_RELEASE,
+                                 mods);
+        }
+        else if (event->xbutton.button == Button2)
+        {
+            _glfwInputMouseClick(window,
+                                 GLFW_MOUSE_BUTTON_MIDDLE,
+                                 GLFW_RELEASE,
+                                 mods);
+        }
+        else if (event->xbutton.button == Button3)
+        {
+            _glfwInputMouseClick(window,
+                                 GLFW_MOUSE_BUTTON_RIGHT,
+                                 GLFW_RELEASE,
+                                 mods);
+        }
+        else if (event->xbutton.button > Button7)
+        {
+            // Additional buttons after 7 are treated as regular buttons
+            // We subtract 4 to fill the gap left by scroll input above
+            _glfwInputMouseClick(window,
+                                 event->xbutton.button - Button1 - 4,
+                                 GLFW_RELEASE,
+                                 mods);
+        }
+
+        return;
+    }
+
+    case EnterNotify:
+    {
+        // XEnterWindowEvent is XCrossingEvent
+        const int x = event->xcrossing.x;
+        const int y = event->xcrossing.y;
+
+        // HACK: This is a workaround for WMs (KWM, Fluxbox) that otherwise
+        //       ignore the defined cursor for hidden cursor mode
+        if (window->cursorMode == GLFW_CURSOR_HIDDEN)
+            updateCursorImage(window);
+
+        _glfwInputCursorEnter(window, GLFW_TRUE);
+        _glfwInputCursorPos(window, x, y);
+
+        window->x11.lastCursorPosX = x;
+        window->x11.lastCursorPosY = y;
+        return;
+    }
+
+    case LeaveNotify:
+    {
+        _glfwInputCursorEnter(window, GLFW_FALSE);
+        return;
+    }
+
+    case MotionNotify:
+    {
+        const int x = event->xmotion.x;
+        const int y = event->xmotion.y;
+
+        if (x != window->x11.warpCursorPosX ||
+            y != window->x11.warpCursorPosY)
+        {
+            // The cursor was moved by something other than GLFW
+
+            if (window->cursorMode == GLFW_CURSOR_DISABLED)
+            {
+                if (_glfw.x11.disabledCursorWindow != window)
+                    return;
+                if (window->rawMouseMotion)
+                    return;
+
+                const int dx = x - window->x11.lastCursorPosX;
+                const int dy = y - window->x11.lastCursorPosY;
+
+                _glfwInputCursorPos(window,
+                                    window->virtualCursorPosX + dx,
+                                    window->virtualCursorPosY + dy);
+            }
+            else
+                _glfwInputCursorPos(window, x, y);
+        }
+
+        window->x11.lastCursorPosX = x;
+        window->x11.lastCursorPosY = y;
+        return;
+    }
+
+    case ConfigureNotify:
+    {
+        if (event->xconfigure.width != window->x11.width ||
+            event->xconfigure.height != window->x11.height)
+        {
+            _glfwInputFramebufferSize(window,
+                                      event->xconfigure.width,
+                                      event->xconfigure.height);
+
+            _glfwInputWindowSize(window,
+                                 event->xconfigure.width,
+                                 event->xconfigure.height);
+
+            window->x11.width = event->xconfigure.width;
+            window->x11.height = event->xconfigure.height;
+        }
+
+        int xpos = event->xconfigure.x;
+        int ypos = event->xconfigure.y;
+
+        // NOTE: ConfigureNotify events from the server are in local
+        //       coordinates, so if we are reparented we need to translate
+        //       the position into root (screen) coordinates
+        if (!event->xany.send_event && window->x11.parent != _glfw.x11.root)
+        {
+            _glfwGrabErrorHandlerX11();
+
+            Window dummy;
+            XTranslateCoordinates(_glfw.x11.display,
+                                  window->x11.parent,
+                                  _glfw.x11.root,
+                                  xpos, ypos,
+                                  &xpos, &ypos,
+                                  &dummy);
+
+            _glfwReleaseErrorHandlerX11();
+            if (_glfw.x11.errorCode == BadWindow)
+                return;
+        }
+
+        if (xpos != window->x11.xpos || ypos != window->x11.ypos)
+        {
+            _glfwInputWindowPos(window, xpos, ypos);
+            window->x11.xpos = xpos;
+            window->x11.ypos = ypos;
+        }
+
+        return;
+    }
+
+    case ClientMessage:
+    {
+        // Custom client message, probably from the window manager
+
+        if (filtered)
+            return;
+
+        if (event->xclient.message_type == None)
+            return;
+
+        if (event->xclient.message_type == _glfw.x11.WM_PROTOCOLS)
+        {
+            const Atom protocol = event->xclient.data.l[0];
+            if (protocol == None)
+                return;
+
+            if (protocol == _glfw.x11.WM_DELETE_WINDOW)
+            {
+                // The window manager was asked to close the window, for
+                // example by the user pressing a 'close' window decoration
+                // button
+                _glfwInputWindowCloseRequest(window);
+            }
+            else if (protocol == _glfw.x11.NET_WM_PING)
+            {
+                // The window manager is pinging the application to ensure
+                // it's still responding to events
+
+                XEvent reply = *event;
+                reply.xclient.window = _glfw.x11.root;
+
+                XSendEvent(_glfw.x11.display, _glfw.x11.root,
+                           False,
+                           SubstructureNotifyMask | SubstructureRedirectMask,
+                           &reply);
+            }
+        }
+        else if (event->xclient.message_type == _glfw.x11.XdndEnter)
+        {
+            // A drag operation has entered the window
+            unsigned long i, count;
+            Atom *formats = NULL;
+            const GLFWbool list = event->xclient.data.l[1] & 1;
+
+            _glfw.x11.xdnd.source = event->xclient.data.l[0];
+            _glfw.x11.xdnd.version = event->xclient.data.l[1] >> 24;
+            _glfw.x11.xdnd.format = None;
+
+            if (_glfw.x11.xdnd.version > _GLFW_XDND_VERSION)
+                return;
+
+            if (list)
+            {
+                count = _glfwGetWindowPropertyX11(_glfw.x11.xdnd.source,
+                                                  _glfw.x11.XdndTypeList,
+                                                  XA_ATOM,
+                                                  (unsigned char **)&formats);
             }
             else
             {
-                KeySym keysym;
-                XLookupString(&event->xkey, NULL, 0, &keysym, NULL);
-
-                _glfwInputKey(window, key, keycode, GLFW_PRESS, mods);
-
-                const long character = _glfwKeySym2Unicode(keysym);
-                if (character != -1)
-                    _glfwInputChar(window, character, mods, plain);
+                count = 3;
+                formats = (Atom *)event->xclient.data.l + 2;
             }
 
-            return;
-        }
-
-        case KeyRelease:
-        {
-            const int key = translateKey(keycode);
-            const int mods = translateState(event->xkey.state);
-
-            if (!_glfw.x11.xkb.detectable)
+            for (i = 0; i < count; i++)
             {
-                // HACK: Key repeat events will arrive as KeyRelease/KeyPress
-                //       pairs with similar or identical time stamps
-                //       The key repeat logic in _glfwInputKey expects only key
-                //       presses to repeat, so detect and discard release events
-                if (XEventsQueued(_glfw.x11.display, QueuedAfterReading))
+                if (formats[i] == _glfw.x11.text_uri_list)
                 {
-                    XEvent next;
-                    XPeekEvent(_glfw.x11.display, &next);
-
-                    if (next.type == KeyPress &&
-                        next.xkey.window == event->xkey.window &&
-                        next.xkey.keycode == keycode)
-                    {
-                        // HACK: The time of repeat events sometimes doesn't
-                        //       match that of the press event, so add an
-                        //       epsilon
-                        //       Toshiyuki Takahashi can press a button
-                        //       16 times per second so it's fairly safe to
-                        //       assume that no human is pressing the key 50
-                        //       times per second (value is ms)
-                        if ((next.xkey.time - event->xkey.time) < 20)
-                        {
-                            // This is very likely a server-generated key repeat
-                            // event, so ignore it
-                            return;
-                        }
-                    }
+                    _glfw.x11.xdnd.format = _glfw.x11.text_uri_list;
+                    break;
                 }
             }
 
-            _glfwInputKey(window, key, keycode, GLFW_RELEASE, mods);
-            return;
+            if (list && formats)
+                XFree(formats);
         }
-
-        case ButtonPress:
+        else if (event->xclient.message_type == _glfw.x11.XdndDrop)
         {
-            const int mods = translateState(event->xbutton.state);
+            // The drag operation has finished by dropping on the window
+            Time time = CurrentTime;
 
-            if (event->xbutton.button == Button1)
-                _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_PRESS, mods);
-            else if (event->xbutton.button == Button2)
-                _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_MIDDLE, GLFW_PRESS, mods);
-            else if (event->xbutton.button == Button3)
-                _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_RIGHT, GLFW_PRESS, mods);
-
-            // Modern X provides scroll events as mouse button presses
-            else if (event->xbutton.button == Button4)
-                _glfwInputScroll(window, 0.0, 1.0);
-            else if (event->xbutton.button == Button5)
-                _glfwInputScroll(window, 0.0, -1.0);
-            else if (event->xbutton.button == Button6)
-                _glfwInputScroll(window, 1.0, 0.0);
-            else if (event->xbutton.button == Button7)
-                _glfwInputScroll(window, -1.0, 0.0);
-
-            else
-            {
-                // Additional buttons after 7 are treated as regular buttons
-                // We subtract 4 to fill the gap left by scroll input above
-                _glfwInputMouseClick(window,
-                                     event->xbutton.button - Button1 - 4,
-                                     GLFW_PRESS,
-                                     mods);
-            }
-
-            return;
-        }
-
-        case ButtonRelease:
-        {
-            const int mods = translateState(event->xbutton.state);
-
-            if (event->xbutton.button == Button1)
-            {
-                _glfwInputMouseClick(window,
-                                     GLFW_MOUSE_BUTTON_LEFT,
-                                     GLFW_RELEASE,
-                                     mods);
-            }
-            else if (event->xbutton.button == Button2)
-            {
-                _glfwInputMouseClick(window,
-                                     GLFW_MOUSE_BUTTON_MIDDLE,
-                                     GLFW_RELEASE,
-                                     mods);
-            }
-            else if (event->xbutton.button == Button3)
-            {
-                _glfwInputMouseClick(window,
-                                     GLFW_MOUSE_BUTTON_RIGHT,
-                                     GLFW_RELEASE,
-                                     mods);
-            }
-            else if (event->xbutton.button > Button7)
-            {
-                // Additional buttons after 7 are treated as regular buttons
-                // We subtract 4 to fill the gap left by scroll input above
-                _glfwInputMouseClick(window,
-                                     event->xbutton.button - Button1 - 4,
-                                     GLFW_RELEASE,
-                                     mods);
-            }
-
-            return;
-        }
-
-        case EnterNotify:
-        {
-            // XEnterWindowEvent is XCrossingEvent
-            const int x = event->xcrossing.x;
-            const int y = event->xcrossing.y;
-
-            // HACK: This is a workaround for WMs (KWM, Fluxbox) that otherwise
-            //       ignore the defined cursor for hidden cursor mode
-            if (window->cursorMode == GLFW_CURSOR_HIDDEN)
-                updateCursorImage(window);
-
-            _glfwInputCursorEnter(window, GLFW_TRUE);
-            _glfwInputCursorPos(window, x, y);
-
-            window->x11.lastCursorPosX = x;
-            window->x11.lastCursorPosY = y;
-            return;
-        }
-
-        case LeaveNotify:
-        {
-            _glfwInputCursorEnter(window, GLFW_FALSE);
-            return;
-        }
-
-        case MotionNotify:
-        {
-            const int x = event->xmotion.x;
-            const int y = event->xmotion.y;
-
-            if (x != window->x11.warpCursorPosX ||
-                y != window->x11.warpCursorPosY)
-            {
-                // The cursor was moved by something other than GLFW
-
-                if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                {
-                    if (_glfw.x11.disabledCursorWindow != window)
-                        return;
-                    if (window->rawMouseMotion)
-                        return;
-
-                    const int dx = x - window->x11.lastCursorPosX;
-                    const int dy = y - window->x11.lastCursorPosY;
-
-                    _glfwInputCursorPos(window,
-                                        window->virtualCursorPosX + dx,
-                                        window->virtualCursorPosY + dy);
-                }
-                else
-                    _glfwInputCursorPos(window, x, y);
-            }
-
-            window->x11.lastCursorPosX = x;
-            window->x11.lastCursorPosY = y;
-            return;
-        }
-
-        case ConfigureNotify:
-        {
-            if (event->xconfigure.width != window->x11.width ||
-                event->xconfigure.height != window->x11.height)
-            {
-                _glfwInputFramebufferSize(window,
-                                          event->xconfigure.width,
-                                          event->xconfigure.height);
-
-                _glfwInputWindowSize(window,
-                                     event->xconfigure.width,
-                                     event->xconfigure.height);
-
-                window->x11.width = event->xconfigure.width;
-                window->x11.height = event->xconfigure.height;
-            }
-
-            int xpos = event->xconfigure.x;
-            int ypos = event->xconfigure.y;
-
-            // NOTE: ConfigureNotify events from the server are in local
-            //       coordinates, so if we are reparented we need to translate
-            //       the position into root (screen) coordinates
-            if (!event->xany.send_event && window->x11.parent != _glfw.x11.root)
-            {
-                _glfwGrabErrorHandlerX11();
-
-                Window dummy;
-                XTranslateCoordinates(_glfw.x11.display,
-                                      window->x11.parent,
-                                      _glfw.x11.root,
-                                      xpos, ypos,
-                                      &xpos, &ypos,
-                                      &dummy);
-
-                _glfwReleaseErrorHandlerX11();
-                if (_glfw.x11.errorCode == BadWindow)
-                    return;
-            }
-
-            if (xpos != window->x11.xpos || ypos != window->x11.ypos)
-            {
-                _glfwInputWindowPos(window, xpos, ypos);
-                window->x11.xpos = xpos;
-                window->x11.ypos = ypos;
-            }
-
-            return;
-        }
-
-        case ClientMessage:
-        {
-            // Custom client message, probably from the window manager
-
-            if (filtered)
+            if (_glfw.x11.xdnd.version > _GLFW_XDND_VERSION)
                 return;
 
-            if (event->xclient.message_type == None)
-                return;
-
-            if (event->xclient.message_type == _glfw.x11.WM_PROTOCOLS)
+            if (_glfw.x11.xdnd.format)
             {
-                const Atom protocol = event->xclient.data.l[0];
-                if (protocol == None)
-                    return;
+                if (_glfw.x11.xdnd.version >= 1)
+                    time = event->xclient.data.l[2];
 
-                if (protocol == _glfw.x11.WM_DELETE_WINDOW)
-                {
-                    // The window manager was asked to close the window, for
-                    // example by the user pressing a 'close' window decoration
-                    // button
-                    _glfwInputWindowCloseRequest(window);
-                }
-                else if (protocol == _glfw.x11.NET_WM_PING)
-                {
-                    // The window manager is pinging the application to ensure
-                    // it's still responding to events
-
-                    XEvent reply = *event;
-                    reply.xclient.window = _glfw.x11.root;
-
-                    XSendEvent(_glfw.x11.display, _glfw.x11.root,
-                               False,
-                               SubstructureNotifyMask | SubstructureRedirectMask,
-                               &reply);
-                }
+                // Request the chosen format from the source window
+                XConvertSelection(_glfw.x11.display,
+                                  _glfw.x11.XdndSelection,
+                                  _glfw.x11.xdnd.format,
+                                  _glfw.x11.XdndSelection,
+                                  window->x11.handle,
+                                  time);
             }
-            else if (event->xclient.message_type == _glfw.x11.XdndEnter)
+            else if (_glfw.x11.xdnd.version >= 2)
             {
-                // A drag operation has entered the window
-                unsigned long i, count;
-                Atom* formats = NULL;
-                const GLFWbool list = event->xclient.data.l[1] & 1;
-
-                _glfw.x11.xdnd.source  = event->xclient.data.l[0];
-                _glfw.x11.xdnd.version = event->xclient.data.l[1] >> 24;
-                _glfw.x11.xdnd.format  = None;
-
-                if (_glfw.x11.xdnd.version > _GLFW_XDND_VERSION)
-                    return;
-
-                if (list)
-                {
-                    count = _glfwGetWindowPropertyX11(_glfw.x11.xdnd.source,
-                                                      _glfw.x11.XdndTypeList,
-                                                      XA_ATOM,
-                                                      (unsigned char**) &formats);
-                }
-                else
-                {
-                    count = 3;
-                    formats = (Atom*) event->xclient.data.l + 2;
-                }
-
-                for (i = 0;  i < count;  i++)
-                {
-                    if (formats[i] == _glfw.x11.text_uri_list)
-                    {
-                        _glfw.x11.xdnd.format = _glfw.x11.text_uri_list;
-                        break;
-                    }
-                }
-
-                if (list && formats)
-                    XFree(formats);
-            }
-            else if (event->xclient.message_type == _glfw.x11.XdndDrop)
-            {
-                // The drag operation has finished by dropping on the window
-                Time time = CurrentTime;
-
-                if (_glfw.x11.xdnd.version > _GLFW_XDND_VERSION)
-                    return;
-
-                if (_glfw.x11.xdnd.format)
-                {
-                    if (_glfw.x11.xdnd.version >= 1)
-                        time = event->xclient.data.l[2];
-
-                    // Request the chosen format from the source window
-                    XConvertSelection(_glfw.x11.display,
-                                      _glfw.x11.XdndSelection,
-                                      _glfw.x11.xdnd.format,
-                                      _glfw.x11.XdndSelection,
-                                      window->x11.handle,
-                                      time);
-                }
-                else if (_glfw.x11.xdnd.version >= 2)
-                {
-                    XEvent reply = { ClientMessage };
-                    reply.xclient.window = _glfw.x11.xdnd.source;
-                    reply.xclient.message_type = _glfw.x11.XdndFinished;
-                    reply.xclient.format = 32;
-                    reply.xclient.data.l[0] = window->x11.handle;
-                    reply.xclient.data.l[1] = 0; // The drag was rejected
-                    reply.xclient.data.l[2] = None;
-
-                    XSendEvent(_glfw.x11.display, _glfw.x11.xdnd.source,
-                               False, NoEventMask, &reply);
-                    XFlush(_glfw.x11.display);
-                }
-            }
-            else if (event->xclient.message_type == _glfw.x11.XdndPosition)
-            {
-                // The drag operation has moved over the window
-                const int xabs = (event->xclient.data.l[2] >> 16) & 0xffff;
-                const int yabs = (event->xclient.data.l[2]) & 0xffff;
-                Window dummy;
-                int xpos, ypos;
-
-                if (_glfw.x11.xdnd.version > _GLFW_XDND_VERSION)
-                    return;
-
-                XTranslateCoordinates(_glfw.x11.display,
-                                      _glfw.x11.root,
-                                      window->x11.handle,
-                                      xabs, yabs,
-                                      &xpos, &ypos,
-                                      &dummy);
-
-                _glfwInputCursorPos(window, xpos, ypos);
-
-                XEvent reply = { ClientMessage };
+                XEvent reply = {ClientMessage};
                 reply.xclient.window = _glfw.x11.xdnd.source;
-                reply.xclient.message_type = _glfw.x11.XdndStatus;
+                reply.xclient.message_type = _glfw.x11.XdndFinished;
                 reply.xclient.format = 32;
                 reply.xclient.data.l[0] = window->x11.handle;
-                reply.xclient.data.l[2] = 0; // Specify an empty rectangle
-                reply.xclient.data.l[3] = 0;
-
-                if (_glfw.x11.xdnd.format)
-                {
-                    // Reply that we are ready to copy the dragged data
-                    reply.xclient.data.l[1] = 1; // Accept with no rectangle
-                    if (_glfw.x11.xdnd.version >= 2)
-                        reply.xclient.data.l[4] = _glfw.x11.XdndActionCopy;
-                }
+                reply.xclient.data.l[1] = 0; // The drag was rejected
+                reply.xclient.data.l[2] = None;
 
                 XSendEvent(_glfw.x11.display, _glfw.x11.xdnd.source,
                            False, NoEventMask, &reply);
                 XFlush(_glfw.x11.display);
             }
-
-            return;
         }
-
-        case SelectionNotify:
+        else if (event->xclient.message_type == _glfw.x11.XdndPosition)
         {
-            if (event->xselection.property == _glfw.x11.XdndSelection)
+            // The drag operation has moved over the window
+            const int xabs = (event->xclient.data.l[2] >> 16) & 0xffff;
+            const int yabs = (event->xclient.data.l[2]) & 0xffff;
+            Window dummy;
+            int xpos, ypos;
+
+            if (_glfw.x11.xdnd.version > _GLFW_XDND_VERSION)
+                return;
+
+            XTranslateCoordinates(_glfw.x11.display,
+                                  _glfw.x11.root,
+                                  window->x11.handle,
+                                  xabs, yabs,
+                                  &xpos, &ypos,
+                                  &dummy);
+
+            _glfwInputCursorPos(window, xpos, ypos);
+
+            XEvent reply = {ClientMessage};
+            reply.xclient.window = _glfw.x11.xdnd.source;
+            reply.xclient.message_type = _glfw.x11.XdndStatus;
+            reply.xclient.format = 32;
+            reply.xclient.data.l[0] = window->x11.handle;
+            reply.xclient.data.l[2] = 0; // Specify an empty rectangle
+            reply.xclient.data.l[3] = 0;
+
+            if (_glfw.x11.xdnd.format)
             {
-                // The converted data from the drag operation has arrived
-                char* data;
-                const unsigned long result =
-                    _glfwGetWindowPropertyX11(event->xselection.requestor,
-                                              event->xselection.property,
-                                              event->xselection.target,
-                                              (unsigned char**) &data);
-
-                if (result)
-                {
-                    int i, count;
-                    char** paths = parseUriList(data, &count);
-
-                    _glfwInputDrop(window, count, (const char**) paths);
-
-                    for (i = 0;  i < count;  i++)
-                        _glfw_free(paths[i]);
-                    _glfw_free(paths);
-                }
-
-                if (data)
-                    XFree(data);
-
+                // Reply that we are ready to copy the dragged data
+                reply.xclient.data.l[1] = 1; // Accept with no rectangle
                 if (_glfw.x11.xdnd.version >= 2)
-                {
-                    XEvent reply = { ClientMessage };
-                    reply.xclient.window = _glfw.x11.xdnd.source;
-                    reply.xclient.message_type = _glfw.x11.XdndFinished;
-                    reply.xclient.format = 32;
-                    reply.xclient.data.l[0] = window->x11.handle;
-                    reply.xclient.data.l[1] = result;
-                    reply.xclient.data.l[2] = _glfw.x11.XdndActionCopy;
-
-                    XSendEvent(_glfw.x11.display, _glfw.x11.xdnd.source,
-                               False, NoEventMask, &reply);
-                    XFlush(_glfw.x11.display);
-                }
+                    reply.xclient.data.l[4] = _glfw.x11.XdndActionCopy;
             }
 
+            XSendEvent(_glfw.x11.display, _glfw.x11.xdnd.source,
+                       False, NoEventMask, &reply);
+            XFlush(_glfw.x11.display);
+        }
+
+        return;
+    }
+
+    case SelectionNotify:
+    {
+        if (event->xselection.property == _glfw.x11.XdndSelection)
+        {
+            // The converted data from the drag operation has arrived
+            char *data;
+            const unsigned long result =
+                _glfwGetWindowPropertyX11(event->xselection.requestor,
+                                          event->xselection.property,
+                                          event->xselection.target,
+                                          (unsigned char **)&data);
+
+            if (result)
+            {
+                int i, count;
+                char **paths = parseUriList(data, &count);
+
+                _glfwInputDrop(window, count, (const char **)paths);
+
+                for (i = 0; i < count; i++)
+                    _glfw_free(paths[i]);
+                _glfw_free(paths);
+            }
+
+            if (data)
+                XFree(data);
+
+            if (_glfw.x11.xdnd.version >= 2)
+            {
+                XEvent reply = {ClientMessage};
+                reply.xclient.window = _glfw.x11.xdnd.source;
+                reply.xclient.message_type = _glfw.x11.XdndFinished;
+                reply.xclient.format = 32;
+                reply.xclient.data.l[0] = window->x11.handle;
+                reply.xclient.data.l[1] = result;
+                reply.xclient.data.l[2] = _glfw.x11.XdndActionCopy;
+
+                XSendEvent(_glfw.x11.display, _glfw.x11.xdnd.source,
+                           False, NoEventMask, &reply);
+                XFlush(_glfw.x11.display);
+            }
+        }
+
+        return;
+    }
+
+    case FocusIn:
+    {
+        if (event->xfocus.mode == NotifyGrab ||
+            event->xfocus.mode == NotifyUngrab)
+        {
+            // Ignore focus events from popup indicator windows, window menu
+            // key chords and window dragging
             return;
         }
 
-        case FocusIn:
+        if (window->cursorMode == GLFW_CURSOR_DISABLED)
+            disableCursor(window);
+
+        if (window->x11.ic)
+            XSetICFocus(window->x11.ic);
+
+        _glfwInputWindowFocus(window, GLFW_TRUE);
+        return;
+    }
+
+    case FocusOut:
+    {
+        if (event->xfocus.mode == NotifyGrab ||
+            event->xfocus.mode == NotifyUngrab)
         {
-            if (event->xfocus.mode == NotifyGrab ||
-                event->xfocus.mode == NotifyUngrab)
-            {
-                // Ignore focus events from popup indicator windows, window menu
-                // key chords and window dragging
+            // Ignore focus events from popup indicator windows, window menu
+            // key chords and window dragging
+            return;
+        }
+
+        if (window->cursorMode == GLFW_CURSOR_DISABLED)
+            enableCursor(window);
+
+        if (window->x11.ic)
+            XUnsetICFocus(window->x11.ic);
+
+        if (window->monitor && window->autoIconify)
+            _glfwPlatformIconifyWindow(window);
+
+        _glfwInputWindowFocus(window, GLFW_FALSE);
+        return;
+    }
+
+    case Expose:
+    {
+        _glfwInputWindowDamage(window);
+        return;
+    }
+
+    case PropertyNotify:
+    {
+        if (event->xproperty.state != PropertyNewValue)
+            return;
+
+        if (event->xproperty.atom == _glfw.x11.WM_STATE)
+        {
+            const int state = getWindowState(window);
+            if (state != IconicState && state != NormalState)
                 return;
-            }
 
-            if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                disableCursor(window);
-
-            if (window->x11.ic)
-                XSetICFocus(window->x11.ic);
-
-            _glfwInputWindowFocus(window, GLFW_TRUE);
-            return;
-        }
-
-        case FocusOut:
-        {
-            if (event->xfocus.mode == NotifyGrab ||
-                event->xfocus.mode == NotifyUngrab)
+            const GLFWbool iconified = (state == IconicState);
+            if (window->x11.iconified != iconified)
             {
-                // Ignore focus events from popup indicator windows, window menu
-                // key chords and window dragging
-                return;
-            }
-
-            if (window->cursorMode == GLFW_CURSOR_DISABLED)
-                enableCursor(window);
-
-            if (window->x11.ic)
-                XUnsetICFocus(window->x11.ic);
-
-            if (window->monitor && window->autoIconify)
-                _glfwPlatformIconifyWindow(window);
-
-            _glfwInputWindowFocus(window, GLFW_FALSE);
-            return;
-        }
-
-        case Expose:
-        {
-            _glfwInputWindowDamage(window);
-            return;
-        }
-
-        case PropertyNotify:
-        {
-            if (event->xproperty.state != PropertyNewValue)
-                return;
-
-            if (event->xproperty.atom == _glfw.x11.WM_STATE)
-            {
-                const int state = getWindowState(window);
-                if (state != IconicState && state != NormalState)
-                    return;
-
-                const GLFWbool iconified = (state == IconicState);
-                if (window->x11.iconified != iconified)
+                if (window->monitor)
                 {
-                    if (window->monitor)
-                    {
-                        if (iconified)
-                            releaseMonitor(window);
-                        else
-                            acquireMonitor(window);
-                    }
-
-                    window->x11.iconified = iconified;
-                    _glfwInputWindowIconify(window, iconified);
+                    if (iconified)
+                        releaseMonitor(window);
+                    else
+                        acquireMonitor(window);
                 }
+
+                window->x11.iconified = iconified;
+                _glfwInputWindowIconify(window, iconified);
             }
-            else if (event->xproperty.atom == _glfw.x11.NET_WM_STATE)
+        }
+        else if (event->xproperty.atom == _glfw.x11.NET_WM_STATE)
+        {
+            const GLFWbool maximized = _glfwPlatformWindowMaximized(window);
+            if (window->x11.maximized != maximized)
             {
-                const GLFWbool maximized = _glfwPlatformWindowMaximized(window);
-                if (window->x11.maximized != maximized)
-                {
-                    window->x11.maximized = maximized;
-                    _glfwInputWindowMaximize(window, maximized);
-                }
+                window->x11.maximized = maximized;
+                _glfwInputWindowMaximize(window, maximized);
             }
-
-            return;
         }
 
-        case DestroyNotify:
-            return;
+        return;
+    }
+
+    case DestroyNotify:
+        return;
     }
 }
-
 
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW internal API                      //////
@@ -1860,7 +1934,7 @@ static void processEvent(XEvent *event)
 unsigned long _glfwGetWindowPropertyX11(Window window,
                                         Atom property,
                                         Atom type,
-                                        unsigned char** value)
+                                        unsigned char **value)
 {
     Atom actualType;
     int actualFormat;
@@ -1882,12 +1956,12 @@ unsigned long _glfwGetWindowPropertyX11(Window window,
     return itemCount;
 }
 
-GLFWbool _glfwIsVisualTransparentX11(Visual* visual)
+GLFWbool _glfwIsVisualTransparentX11(Visual *visual)
 {
     if (!_glfw.x11.xrender.available)
         return GLFW_FALSE;
 
-    XRenderPictFormat* pf = XRenderFindVisualFormat(_glfw.x11.display, visual);
+    XRenderPictFormat *pf = XRenderFindVisualFormat(_glfw.x11.display, visual);
     return pf && pf->direct.alphaMask;
 }
 
@@ -1910,28 +1984,28 @@ void _glfwPushSelectionToManagerX11(void)
         {
             switch (event.type)
             {
-                case SelectionRequest:
-                    handleSelectionRequest(&event);
-                    break;
+            case SelectionRequest:
+                handleSelectionRequest(&event);
+                break;
 
-                case SelectionClear:
-                    handleSelectionClear(&event);
-                    break;
+            case SelectionClear:
+                handleSelectionClear(&event);
+                break;
 
-                case SelectionNotify:
+            case SelectionNotify:
+            {
+                if (event.xselection.target == _glfw.x11.SAVE_TARGETS)
                 {
-                    if (event.xselection.target == _glfw.x11.SAVE_TARGETS)
-                    {
-                        // This means one of two things; either the selection
-                        // was not owned, which means there is no clipboard
-                        // manager, or the transfer to the clipboard manager has
-                        // completed
-                        // In either case, it means we are done here
-                        return;
-                    }
-
-                    break;
+                    // This means one of two things; either the selection
+                    // was not owned, which means there is no clipboard
+                    // manager, or the transfer to the clipboard manager has
+                    // completed
+                    // In either case, it means we are done here
+                    return;
                 }
+
+                break;
+            }
             }
         }
 
@@ -1939,11 +2013,11 @@ void _glfwPushSelectionToManagerX11(void)
     }
 }
 
-void _glfwCreateInputContextX11(_GLFWwindow* window)
+void _glfwCreateInputContextX11(_GLFWwindow *window)
 {
     XIMCallback callback;
-    callback.callback = (XIMProc) inputContextDestroyCallback;
-    callback.client_data = (XPointer) window;
+    callback.callback = (XIMProc)inputContextDestroyCallback;
+    callback.client_data = (XPointer)window;
 
     window->x11.ic = XCreateIC(_glfw.x11.im,
                                XNInputStyle,
@@ -1971,17 +2045,16 @@ void _glfwCreateInputContextX11(_GLFWwindow* window)
     }
 }
 
-
 //////////////////////////////////////////////////////////////////////////
 //////                       GLFW platform API                      //////
 //////////////////////////////////////////////////////////////////////////
 
-int _glfwPlatformCreateWindow(_GLFWwindow* window,
-                              const _GLFWwndconfig* wndconfig,
-                              const _GLFWctxconfig* ctxconfig,
-                              const _GLFWfbconfig* fbconfig)
+int _glfwPlatformCreateWindow(_GLFWwindow *window,
+                              const _GLFWwndconfig *wndconfig,
+                              const _GLFWctxconfig *ctxconfig,
+                              const _GLFWfbconfig *fbconfig)
 {
-    Visual* visual = NULL;
+    Visual *visual = NULL;
     int depth;
 
     if (ctxconfig->client != GLFW_NO_API)
@@ -2046,7 +2119,7 @@ int _glfwPlatformCreateWindow(_GLFWwindow* window,
     return GLFW_TRUE;
 }
 
-void _glfwPlatformDestroyWindow(_GLFWwindow* window)
+void _glfwPlatformDestroyWindow(_GLFWwindow *window)
 {
     if (_glfw.x11.disabledCursorWindow == window)
         _glfw.x11.disabledCursorWindow = NULL;
@@ -2068,19 +2141,19 @@ void _glfwPlatformDestroyWindow(_GLFWwindow* window)
         XDeleteContext(_glfw.x11.display, window->x11.handle, _glfw.x11.context);
         XUnmapWindow(_glfw.x11.display, window->x11.handle);
         XDestroyWindow(_glfw.x11.display, window->x11.handle);
-        window->x11.handle = (Window) 0;
+        window->x11.handle = (Window)0;
     }
 
     if (window->x11.colormap)
     {
         XFreeColormap(_glfw.x11.display, window->x11.colormap);
-        window->x11.colormap = (Colormap) 0;
+        window->x11.colormap = (Colormap)0;
     }
 
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformSetWindowTitle(_GLFWwindow* window, const char* title)
+void _glfwPlatformSetWindowTitle(_GLFWwindow *window, const char *title)
 {
     if (_glfw.x11.xlib.utf8)
     {
@@ -2091,42 +2164,42 @@ void _glfwPlatformSetWindowTitle(_GLFWwindow* window, const char* title)
                              NULL, NULL, NULL);
     }
 
-    XChangeProperty(_glfw.x11.display,  window->x11.handle,
+    XChangeProperty(_glfw.x11.display, window->x11.handle,
                     _glfw.x11.NET_WM_NAME, _glfw.x11.UTF8_STRING, 8,
                     PropModeReplace,
-                    (unsigned char*) title, strlen(title));
+                    (unsigned char *)title, strlen(title));
 
-    XChangeProperty(_glfw.x11.display,  window->x11.handle,
+    XChangeProperty(_glfw.x11.display, window->x11.handle,
                     _glfw.x11.NET_WM_ICON_NAME, _glfw.x11.UTF8_STRING, 8,
                     PropModeReplace,
-                    (unsigned char*) title, strlen(title));
+                    (unsigned char *)title, strlen(title));
 
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformSetWindowIcon(_GLFWwindow* window,
-                                int count, const GLFWimage* images)
+void _glfwPlatformSetWindowIcon(_GLFWwindow *window,
+                                int count, const GLFWimage *images)
 {
     if (count)
     {
         int i, j, longCount = 0;
 
-        for (i = 0;  i < count;  i++)
+        for (i = 0; i < count; i++)
             longCount += 2 + images[i].width * images[i].height;
 
-        long* icon = _glfw_calloc(longCount, sizeof(long));
-        long* target = icon;
+        long *icon = _glfw_calloc(longCount, sizeof(long));
+        long *target = icon;
 
-        for (i = 0;  i < count;  i++)
+        for (i = 0; i < count; i++)
         {
             *target++ = images[i].width;
             *target++ = images[i].height;
 
-            for (j = 0;  j < images[i].width * images[i].height;  j++)
+            for (j = 0; j < images[i].width * images[i].height; j++)
             {
                 *target++ = (images[i].pixels[j * 4 + 0] << 16) |
-                            (images[i].pixels[j * 4 + 1] <<  8) |
-                            (images[i].pixels[j * 4 + 2] <<  0) |
+                            (images[i].pixels[j * 4 + 1] << 8) |
+                            (images[i].pixels[j * 4 + 2] << 0) |
                             (images[i].pixels[j * 4 + 3] << 24);
             }
         }
@@ -2135,7 +2208,7 @@ void _glfwPlatformSetWindowIcon(_GLFWwindow* window,
                         _glfw.x11.NET_WM_ICON,
                         XA_CARDINAL, 32,
                         PropModeReplace,
-                        (unsigned char*) icon,
+                        (unsigned char *)icon,
                         longCount);
 
         _glfw_free(icon);
@@ -2149,7 +2222,7 @@ void _glfwPlatformSetWindowIcon(_GLFWwindow* window,
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformGetWindowPos(_GLFWwindow* window, int* xpos, int* ypos)
+void _glfwPlatformGetWindowPos(_GLFWwindow *window, int *xpos, int *ypos)
 {
     Window dummy;
     int x, y;
@@ -2163,14 +2236,14 @@ void _glfwPlatformGetWindowPos(_GLFWwindow* window, int* xpos, int* ypos)
         *ypos = y;
 }
 
-void _glfwPlatformSetWindowPos(_GLFWwindow* window, int xpos, int ypos)
+void _glfwPlatformSetWindowPos(_GLFWwindow *window, int xpos, int ypos)
 {
     // HACK: Explicitly setting PPosition to any value causes some WMs, notably
     //       Compiz and Metacity, to honor the position of unmapped windows
     if (!_glfwPlatformWindowVisible(window))
     {
         long supplied;
-        XSizeHints* hints = XAllocSizeHints();
+        XSizeHints *hints = XAllocSizeHints();
 
         if (XGetWMNormalHints(_glfw.x11.display, window->x11.handle, hints, &supplied))
         {
@@ -2187,7 +2260,7 @@ void _glfwPlatformSetWindowPos(_GLFWwindow* window, int xpos, int ypos)
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformGetWindowSize(_GLFWwindow* window, int* width, int* height)
+void _glfwPlatformGetWindowSize(_GLFWwindow *window, int *width, int *height)
 {
     XWindowAttributes attribs;
     XGetWindowAttributes(_glfw.x11.display, window->x11.handle, &attribs);
@@ -2198,7 +2271,7 @@ void _glfwPlatformGetWindowSize(_GLFWwindow* window, int* width, int* height)
         *height = attribs.height;
 }
 
-void _glfwPlatformSetWindowSize(_GLFWwindow* window, int width, int height)
+void _glfwPlatformSetWindowSize(_GLFWwindow *window, int width, int height)
 {
     if (window->monitor)
     {
@@ -2216,7 +2289,7 @@ void _glfwPlatformSetWindowSize(_GLFWwindow* window, int width, int height)
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformSetWindowSizeLimits(_GLFWwindow* window,
+void _glfwPlatformSetWindowSizeLimits(_GLFWwindow *window,
                                       int minwidth, int minheight,
                                       int maxwidth, int maxheight)
 {
@@ -2226,7 +2299,7 @@ void _glfwPlatformSetWindowSizeLimits(_GLFWwindow* window,
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformSetWindowAspectRatio(_GLFWwindow* window, int numer, int denom)
+void _glfwPlatformSetWindowAspectRatio(_GLFWwindow *window, int numer, int denom)
 {
     int width, height;
     _glfwPlatformGetWindowSize(window, &width, &height);
@@ -2234,16 +2307,16 @@ void _glfwPlatformSetWindowAspectRatio(_GLFWwindow* window, int numer, int denom
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformGetFramebufferSize(_GLFWwindow* window, int* width, int* height)
+void _glfwPlatformGetFramebufferSize(_GLFWwindow *window, int *width, int *height)
 {
     _glfwPlatformGetWindowSize(window, width, height);
 }
 
-void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
-                                     int* left, int* top,
-                                     int* right, int* bottom)
+void _glfwPlatformGetWindowFrameSize(_GLFWwindow *window,
+                                     int *left, int *top,
+                                     int *right, int *bottom)
 {
-    long* extents = NULL;
+    long *extents = NULL;
 
     if (window->monitor || !window->decorated)
         return;
@@ -2270,7 +2343,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
         while (!XCheckIfEvent(_glfw.x11.display,
                               &event,
                               isFrameExtentsEvent,
-                              (XPointer) window))
+                              (XPointer)window))
         {
             if (!waitForEvent(&timeout))
             {
@@ -2284,7 +2357,7 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
     if (_glfwGetWindowPropertyX11(window->x11.handle,
                                   _glfw.x11.NET_FRAME_EXTENTS,
                                   XA_CARDINAL,
-                                  (unsigned char**) &extents) == 4)
+                                  (unsigned char **)&extents) == 4)
     {
         if (left)
             *left = extents[0];
@@ -2300,8 +2373,8 @@ void _glfwPlatformGetWindowFrameSize(_GLFWwindow* window,
         XFree(extents);
 }
 
-void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
-                                        float* xscale, float* yscale)
+void _glfwPlatformGetWindowContentScale(_GLFWwindow *window,
+                                        float *xscale, float *yscale)
 {
     if (xscale)
         *xscale = _glfw.x11.contentScaleX;
@@ -2309,7 +2382,7 @@ void _glfwPlatformGetWindowContentScale(_GLFWwindow* window,
         *yscale = _glfw.x11.contentScaleY;
 }
 
-void _glfwPlatformIconifyWindow(_GLFWwindow* window)
+void _glfwPlatformIconifyWindow(_GLFWwindow *window)
 {
     if (window->x11.overrideRedirect)
     {
@@ -2324,7 +2397,7 @@ void _glfwPlatformIconifyWindow(_GLFWwindow* window)
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformRestoreWindow(_GLFWwindow* window)
+void _glfwPlatformRestoreWindow(_GLFWwindow *window)
 {
     if (window->x11.overrideRedirect)
     {
@@ -2358,7 +2431,7 @@ void _glfwPlatformRestoreWindow(_GLFWwindow* window)
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformMaximizeWindow(_GLFWwindow* window)
+void _glfwPlatformMaximizeWindow(_GLFWwindow *window)
 {
     if (!_glfw.x11.NET_WM_STATE ||
         !_glfw.x11.NET_WM_STATE_MAXIMIZED_VERT ||
@@ -2370,34 +2443,33 @@ void _glfwPlatformMaximizeWindow(_GLFWwindow* window)
     if (_glfwPlatformWindowVisible(window))
     {
         sendEventToWM(window,
-                    _glfw.x11.NET_WM_STATE,
-                    _NET_WM_STATE_ADD,
-                    _glfw.x11.NET_WM_STATE_MAXIMIZED_VERT,
-                    _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ,
-                    1, 0);
+                      _glfw.x11.NET_WM_STATE,
+                      _NET_WM_STATE_ADD,
+                      _glfw.x11.NET_WM_STATE_MAXIMIZED_VERT,
+                      _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ,
+                      1, 0);
     }
     else
     {
-        Atom* states = NULL;
+        Atom *states = NULL;
         unsigned long count =
             _glfwGetWindowPropertyX11(window->x11.handle,
                                       _glfw.x11.NET_WM_STATE,
                                       XA_ATOM,
-                                      (unsigned char**) &states);
+                                      (unsigned char **)&states);
 
         // NOTE: We don't check for failure as this property may not exist yet
         //       and that's fine (and we'll create it implicitly with append)
 
         Atom missing[2] =
-        {
-            _glfw.x11.NET_WM_STATE_MAXIMIZED_VERT,
-            _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ
-        };
+            {
+                _glfw.x11.NET_WM_STATE_MAXIMIZED_VERT,
+                _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ};
         unsigned long missingCount = 2;
 
-        for (unsigned long i = 0;  i < count;  i++)
+        for (unsigned long i = 0; i < count; i++)
         {
-            for (unsigned long j = 0;  j < missingCount;  j++)
+            for (unsigned long j = 0; j < missingCount; j++)
             {
                 if (states[i] == missing[j])
                 {
@@ -2416,14 +2488,14 @@ void _glfwPlatformMaximizeWindow(_GLFWwindow* window)
         XChangeProperty(_glfw.x11.display, window->x11.handle,
                         _glfw.x11.NET_WM_STATE, XA_ATOM, 32,
                         PropModeAppend,
-                        (unsigned char*) missing,
+                        (unsigned char *)missing,
                         missingCount);
     }
 
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformShowWindow(_GLFWwindow* window)
+void _glfwPlatformShowWindow(_GLFWwindow *window)
 {
     if (_glfwPlatformWindowVisible(window))
         return;
@@ -2432,13 +2504,13 @@ void _glfwPlatformShowWindow(_GLFWwindow* window)
     waitForVisibilityNotify(window);
 }
 
-void _glfwPlatformHideWindow(_GLFWwindow* window)
+void _glfwPlatformHideWindow(_GLFWwindow *window)
 {
     XUnmapWindow(_glfw.x11.display, window->x11.handle);
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
+void _glfwPlatformRequestWindowAttention(_GLFWwindow *window)
 {
     if (!_glfw.x11.NET_WM_STATE || !_glfw.x11.NET_WM_STATE_DEMANDS_ATTENTION)
         return;
@@ -2450,7 +2522,7 @@ void _glfwPlatformRequestWindowAttention(_GLFWwindow* window)
                   0, 1, 0);
 }
 
-void _glfwPlatformFocusWindow(_GLFWwindow* window)
+void _glfwPlatformFocusWindow(_GLFWwindow *window)
 {
     if (_glfw.x11.NET_ACTIVE_WINDOW)
         sendEventToWM(window, _glfw.x11.NET_ACTIVE_WINDOW, 1, 0, 0, 0, 0);
@@ -2464,8 +2536,8 @@ void _glfwPlatformFocusWindow(_GLFWwindow* window)
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
-                                   _GLFWmonitor* monitor,
+void _glfwPlatformSetWindowMonitor(_GLFWwindow *window,
+                                   _GLFWmonitor *monitor,
                                    int xpos, int ypos,
                                    int width, int height,
                                    int refreshRate)
@@ -2521,7 +2593,7 @@ void _glfwPlatformSetWindowMonitor(_GLFWwindow* window,
     XFlush(_glfw.x11.display);
 }
 
-int _glfwPlatformWindowFocused(_GLFWwindow* window)
+int _glfwPlatformWindowFocused(_GLFWwindow *window)
 {
     Window focused;
     int state;
@@ -2530,21 +2602,21 @@ int _glfwPlatformWindowFocused(_GLFWwindow* window)
     return window->x11.handle == focused;
 }
 
-int _glfwPlatformWindowIconified(_GLFWwindow* window)
+int _glfwPlatformWindowIconified(_GLFWwindow *window)
 {
     return getWindowState(window) == IconicState;
 }
 
-int _glfwPlatformWindowVisible(_GLFWwindow* window)
+int _glfwPlatformWindowVisible(_GLFWwindow *window)
 {
     XWindowAttributes wa;
     XGetWindowAttributes(_glfw.x11.display, window->x11.handle, &wa);
     return wa.map_state == IsViewable;
 }
 
-int _glfwPlatformWindowMaximized(_GLFWwindow* window)
+int _glfwPlatformWindowMaximized(_GLFWwindow *window)
 {
-    Atom* states;
+    Atom *states;
     unsigned long i;
     GLFWbool maximized = GLFW_FALSE;
 
@@ -2559,9 +2631,9 @@ int _glfwPlatformWindowMaximized(_GLFWwindow* window)
         _glfwGetWindowPropertyX11(window->x11.handle,
                                   _glfw.x11.NET_WM_STATE,
                                   XA_ATOM,
-                                  (unsigned char**) &states);
+                                  (unsigned char **)&states);
 
-    for (i = 0;  i < count;  i++)
+    for (i = 0; i < count; i++)
     {
         if (states[i] == _glfw.x11.NET_WM_STATE_MAXIMIZED_VERT ||
             states[i] == _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ)
@@ -2577,7 +2649,7 @@ int _glfwPlatformWindowMaximized(_GLFWwindow* window)
     return maximized;
 }
 
-int _glfwPlatformWindowHovered(_GLFWwindow* window)
+int _glfwPlatformWindowHovered(_GLFWwindow *window)
 {
     Window w = _glfw.x11.root;
     while (w)
@@ -2605,7 +2677,7 @@ int _glfwPlatformWindowHovered(_GLFWwindow* window)
     return GLFW_FALSE;
 }
 
-int _glfwPlatformFramebufferTransparent(_GLFWwindow* window)
+int _glfwPlatformFramebufferTransparent(_GLFWwindow *window)
 {
     if (!window->x11.transparent)
         return GLFW_FALSE;
@@ -2613,14 +2685,14 @@ int _glfwPlatformFramebufferTransparent(_GLFWwindow* window)
     return XGetSelectionOwner(_glfw.x11.display, _glfw.x11.NET_WM_CM_Sx) != None;
 }
 
-void _glfwPlatformSetWindowResizable(_GLFWwindow* window, GLFWbool enabled)
+void _glfwPlatformSetWindowResizable(_GLFWwindow *window, GLFWbool enabled)
 {
     int width, height;
     _glfwPlatformGetWindowSize(window, &width, &height);
     updateNormalHints(window, width, height);
 }
 
-void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
+void _glfwPlatformSetWindowDecorated(_GLFWwindow *window, GLFWbool enabled)
 {
     struct
     {
@@ -2638,11 +2710,11 @@ void _glfwPlatformSetWindowDecorated(_GLFWwindow* window, GLFWbool enabled)
                     _glfw.x11.MOTIF_WM_HINTS,
                     _glfw.x11.MOTIF_WM_HINTS, 32,
                     PropModeReplace,
-                    (unsigned char*) &hints,
+                    (unsigned char *)&hints,
                     sizeof(hints) / sizeof(long));
 }
 
-void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
+void _glfwPlatformSetWindowFloating(_GLFWwindow *window, GLFWbool enabled)
 {
     if (!_glfw.x11.NET_WM_STATE || !_glfw.x11.NET_WM_STATE_ABOVE)
         return;
@@ -2658,20 +2730,20 @@ void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
     }
     else
     {
-        Atom* states = NULL;
+        Atom *states = NULL;
         unsigned long i, count;
 
         count = _glfwGetWindowPropertyX11(window->x11.handle,
                                           _glfw.x11.NET_WM_STATE,
                                           XA_ATOM,
-                                          (unsigned char**) &states);
+                                          (unsigned char **)&states);
 
         // NOTE: We don't check for failure as this property may not exist yet
         //       and that's fine (and we'll create it implicitly with append)
 
         if (enabled)
         {
-            for (i = 0;  i < count;  i++)
+            for (i = 0; i < count; i++)
             {
                 if (states[i] == _glfw.x11.NET_WM_STATE_ABOVE)
                     break;
@@ -2682,13 +2754,13 @@ void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
                 XChangeProperty(_glfw.x11.display, window->x11.handle,
                                 _glfw.x11.NET_WM_STATE, XA_ATOM, 32,
                                 PropModeAppend,
-                                (unsigned char*) &_glfw.x11.NET_WM_STATE_ABOVE,
+                                (unsigned char *)&_glfw.x11.NET_WM_STATE_ABOVE,
                                 1);
             }
         }
         else if (states)
         {
-            for (i = 0;  i < count;  i++)
+            for (i = 0; i < count; i++)
             {
                 if (states[i] == _glfw.x11.NET_WM_STATE_ABOVE)
                     break;
@@ -2701,7 +2773,7 @@ void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
 
                 XChangeProperty(_glfw.x11.display, window->x11.handle,
                                 _glfw.x11.NET_WM_STATE, XA_ATOM, 32,
-                                PropModeReplace, (unsigned char*) states, count);
+                                PropModeReplace, (unsigned char *)states, count);
             }
         }
 
@@ -2712,7 +2784,7 @@ void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformSetWindowMousePassthrough(_GLFWwindow* window, GLFWbool enabled)
+void _glfwPlatformSetWindowMousePassthrough(_GLFWwindow *window, GLFWbool enabled)
 {
     if (!_glfw.x11.xshape.available)
         return;
@@ -2731,20 +2803,20 @@ void _glfwPlatformSetWindowMousePassthrough(_GLFWwindow* window, GLFWbool enable
     }
 }
 
-float _glfwPlatformGetWindowOpacity(_GLFWwindow* window)
+float _glfwPlatformGetWindowOpacity(_GLFWwindow *window)
 {
     float opacity = 1.f;
 
     if (XGetSelectionOwner(_glfw.x11.display, _glfw.x11.NET_WM_CM_Sx))
     {
-        CARD32* value = NULL;
+        CARD32 *value = NULL;
 
         if (_glfwGetWindowPropertyX11(window->x11.handle,
                                       _glfw.x11.NET_WM_WINDOW_OPACITY,
                                       XA_CARDINAL,
-                                      (unsigned char**) &value))
+                                      (unsigned char **)&value))
         {
-            opacity = (float) (*value / (double) 0xffffffffu);
+            opacity = (float)(*value / (double)0xffffffffu);
         }
 
         if (value)
@@ -2754,12 +2826,12 @@ float _glfwPlatformGetWindowOpacity(_GLFWwindow* window)
     return opacity;
 }
 
-void _glfwPlatformSetWindowOpacity(_GLFWwindow* window, float opacity)
+void _glfwPlatformSetWindowOpacity(_GLFWwindow *window, float opacity)
 {
-    const CARD32 value = (CARD32) (0xffffffffu * (double) opacity);
+    const CARD32 value = (CARD32)(0xffffffffu * (double)opacity);
     XChangeProperty(_glfw.x11.display, window->x11.handle,
                     _glfw.x11.NET_WM_WINDOW_OPACITY, XA_CARDINAL, 32,
-                    PropModeReplace, (unsigned char*) &value, 1);
+                    PropModeReplace, (unsigned char *)&value, 1);
 }
 
 void _glfwPlatformSetRawMouseMotion(_GLFWwindow *window, GLFWbool enabled)
@@ -2783,7 +2855,7 @@ GLFWbool _glfwPlatformRawMouseMotionSupported(void)
 
 void _glfwPlatformPollEvents(void)
 {
-    _GLFWwindow* window;
+    _GLFWwindow *window;
 
 #if defined(__linux__)
     if (_glfw.joysticksInitialized)
@@ -2837,7 +2909,7 @@ void _glfwPlatformWaitEventsTimeout(double timeout)
 
 void _glfwPlatformPostEmptyEvent(void)
 {
-    XEvent event = { ClientMessage };
+    XEvent event = {ClientMessage};
     event.xclient.window = _glfw.x11.helperWindowHandle;
     event.xclient.format = 32; // Data is 32-bit longs
     event.xclient.message_type = _glfw.x11.NULL_;
@@ -2846,7 +2918,7 @@ void _glfwPlatformPostEmptyEvent(void)
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)
+void _glfwPlatformGetCursorPos(_GLFWwindow *window, double *xpos, double *ypos)
 {
     Window root, child;
     int rootX, rootY, childX, childY;
@@ -2863,18 +2935,18 @@ void _glfwPlatformGetCursorPos(_GLFWwindow* window, double* xpos, double* ypos)
         *ypos = childY;
 }
 
-void _glfwPlatformSetCursorPos(_GLFWwindow* window, double x, double y)
+void _glfwPlatformSetCursorPos(_GLFWwindow *window, double x, double y)
 {
     // Store the new position so it can be recognized later
-    window->x11.warpCursorPosX = (int) x;
-    window->x11.warpCursorPosY = (int) y;
+    window->x11.warpCursorPosX = (int)x;
+    window->x11.warpCursorPosY = (int)y;
 
     XWarpPointer(_glfw.x11.display, None, window->x11.handle,
-                 0,0,0,0, (int) x, (int) y);
+                 0, 0, 0, 0, (int)x, (int)y);
     XFlush(_glfw.x11.display);
 }
 
-void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode)
+void _glfwPlatformSetCursorMode(_GLFWwindow *window, int mode)
 {
     if (mode == GLFW_CURSOR_DISABLED)
     {
@@ -2889,7 +2961,7 @@ void _glfwPlatformSetCursorMode(_GLFWwindow* window, int mode)
     XFlush(_glfw.x11.display);
 }
 
-const char* _glfwPlatformGetScancodeName(int scancode)
+const char *_glfwPlatformGetScancodeName(int scancode)
 {
     if (!_glfw.x11.xkb.available)
         return NULL;
@@ -2911,7 +2983,7 @@ const char* _glfwPlatformGetScancodeName(int scancode)
     if (ch == -1)
         return NULL;
 
-    const size_t count = encodeUTF8(_glfw.x11.keynames[key], (unsigned int) ch);
+    const size_t count = encodeUTF8(_glfw.x11.keynames[key], (unsigned int)ch);
     if (count == 0)
         return NULL;
 
@@ -2924,8 +2996,8 @@ int _glfwPlatformGetKeyScancode(int key)
     return _glfw.x11.scancodes[key];
 }
 
-int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
-                              const GLFWimage* image,
+int _glfwPlatformCreateCursor(_GLFWcursor *cursor,
+                              const GLFWimage *image,
                               int xhot, int yhot)
 {
     cursor->x11.handle = _glfwCreateCursorX11(image, xhot, yhot);
@@ -2935,51 +3007,51 @@ int _glfwPlatformCreateCursor(_GLFWcursor* cursor,
     return GLFW_TRUE;
 }
 
-int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
+int _glfwPlatformCreateStandardCursor(_GLFWcursor *cursor, int shape)
 {
     if (_glfw.x11.xcursor.handle)
     {
-        char* theme = XcursorGetTheme(_glfw.x11.display);
+        char *theme = XcursorGetTheme(_glfw.x11.display);
         if (theme)
         {
             const int size = XcursorGetDefaultSize(_glfw.x11.display);
-            const char* name = NULL;
+            const char *name = NULL;
 
             switch (shape)
             {
-                case GLFW_ARROW_CURSOR:
-                    name = "default";
-                    break;
-                case GLFW_IBEAM_CURSOR:
-                    name = "text";
-                    break;
-                case GLFW_CROSSHAIR_CURSOR:
-                    name = "crosshair";
-                    break;
-                case GLFW_POINTING_HAND_CURSOR:
-                    name = "pointer";
-                    break;
-                case GLFW_RESIZE_EW_CURSOR:
-                    name = "ew-resize";
-                    break;
-                case GLFW_RESIZE_NS_CURSOR:
-                    name = "ns-resize";
-                    break;
-                case GLFW_RESIZE_NWSE_CURSOR:
-                    name = "nwse-resize";
-                    break;
-                case GLFW_RESIZE_NESW_CURSOR:
-                    name = "nesw-resize";
-                    break;
-                case GLFW_RESIZE_ALL_CURSOR:
-                    name = "all-scroll";
-                    break;
-                case GLFW_NOT_ALLOWED_CURSOR:
-                    name = "not-allowed";
-                    break;
+            case GLFW_ARROW_CURSOR:
+                name = "default";
+                break;
+            case GLFW_IBEAM_CURSOR:
+                name = "text";
+                break;
+            case GLFW_CROSSHAIR_CURSOR:
+                name = "crosshair";
+                break;
+            case GLFW_POINTING_HAND_CURSOR:
+                name = "pointer";
+                break;
+            case GLFW_RESIZE_EW_CURSOR:
+                name = "ew-resize";
+                break;
+            case GLFW_RESIZE_NS_CURSOR:
+                name = "ns-resize";
+                break;
+            case GLFW_RESIZE_NWSE_CURSOR:
+                name = "nwse-resize";
+                break;
+            case GLFW_RESIZE_NESW_CURSOR:
+                name = "nesw-resize";
+                break;
+            case GLFW_RESIZE_ALL_CURSOR:
+                name = "all-scroll";
+                break;
+            case GLFW_NOT_ALLOWED_CURSOR:
+                name = "not-allowed";
+                break;
             }
 
-            XcursorImage* image = XcursorLibraryLoadImage(name, theme, size);
+            XcursorImage *image = XcursorLibraryLoadImage(name, theme, size);
             if (image)
             {
                 cursor->x11.handle = XcursorImageLoadCursor(_glfw.x11.display, image);
@@ -2994,31 +3066,31 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
 
         switch (shape)
         {
-            case GLFW_ARROW_CURSOR:
-                native = XC_left_ptr;
-                break;
-            case GLFW_IBEAM_CURSOR:
-                native = XC_xterm;
-                break;
-            case GLFW_CROSSHAIR_CURSOR:
-                native = XC_crosshair;
-                break;
-            case GLFW_POINTING_HAND_CURSOR:
-                native = XC_hand2;
-                break;
-            case GLFW_RESIZE_EW_CURSOR:
-                native = XC_sb_h_double_arrow;
-                break;
-            case GLFW_RESIZE_NS_CURSOR:
-                native = XC_sb_v_double_arrow;
-                break;
-            case GLFW_RESIZE_ALL_CURSOR:
-                native = XC_fleur;
-                break;
-            default:
-                _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
-                                "X11: Standard cursor shape unavailable");
-                return GLFW_FALSE;
+        case GLFW_ARROW_CURSOR:
+            native = XC_left_ptr;
+            break;
+        case GLFW_IBEAM_CURSOR:
+            native = XC_xterm;
+            break;
+        case GLFW_CROSSHAIR_CURSOR:
+            native = XC_crosshair;
+            break;
+        case GLFW_POINTING_HAND_CURSOR:
+            native = XC_hand2;
+            break;
+        case GLFW_RESIZE_EW_CURSOR:
+            native = XC_sb_h_double_arrow;
+            break;
+        case GLFW_RESIZE_NS_CURSOR:
+            native = XC_sb_v_double_arrow;
+            break;
+        case GLFW_RESIZE_ALL_CURSOR:
+            native = XC_fleur;
+            break;
+        default:
+            _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                            "X11: Standard cursor shape unavailable");
+            return GLFW_FALSE;
         }
 
         cursor->x11.handle = XCreateFontCursor(_glfw.x11.display, native);
@@ -3033,13 +3105,13 @@ int _glfwPlatformCreateStandardCursor(_GLFWcursor* cursor, int shape)
     return GLFW_TRUE;
 }
 
-void _glfwPlatformDestroyCursor(_GLFWcursor* cursor)
+void _glfwPlatformDestroyCursor(_GLFWcursor *cursor)
 {
     if (cursor->x11.handle)
         XFreeCursor(_glfw.x11.display, cursor->x11.handle);
 }
 
-void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
+void _glfwPlatformSetCursor(_GLFWwindow *window, _GLFWcursor *cursor)
 {
     if (window->cursorMode == GLFW_CURSOR_NORMAL)
     {
@@ -3048,9 +3120,9 @@ void _glfwPlatformSetCursor(_GLFWwindow* window, _GLFWcursor* cursor)
     }
 }
 
-void _glfwPlatformSetClipboardString(const char* string)
+void _glfwPlatformSetClipboardString(const char *string)
 {
-    char* copy = _glfw_strdup(string);
+    char *copy = _glfw_strdup(string);
     _glfw_free(_glfw.x11.clipboardString);
     _glfw.x11.clipboardString = copy;
 
@@ -3067,12 +3139,12 @@ void _glfwPlatformSetClipboardString(const char* string)
     }
 }
 
-const char* _glfwPlatformGetClipboardString(void)
+const char *_glfwPlatformGetClipboardString(void)
 {
     return getSelectionString(_glfw.x11.CLIPBOARD);
 }
 
-EGLenum _glfwPlatformGetEGLPlatform(EGLint** attribs)
+EGLenum _glfwPlatformGetEGLPlatform(EGLint **attribs)
 {
     if (_glfw.egl.ANGLE_platform_angle)
     {
@@ -3113,15 +3185,15 @@ EGLNativeDisplayType _glfwPlatformGetEGLNativeDisplay(void)
     return _glfw.x11.display;
 }
 
-EGLNativeWindowType _glfwPlatformGetEGLNativeWindow(_GLFWwindow* window)
+EGLNativeWindowType _glfwPlatformGetEGLNativeWindow(_GLFWwindow *window)
 {
     if (_glfw.egl.platform)
         return &window->x11.handle;
     else
-        return (EGLNativeWindowType) window->x11.handle;
+        return (EGLNativeWindowType)window->x11.handle;
 }
 
-void _glfwPlatformGetRequiredInstanceExtensions(char** extensions)
+void _glfwPlatformGetRequiredInstanceExtensions(char **extensions)
 {
     if (!_glfw.vk.KHR_surface)
         return;
@@ -3153,8 +3225,8 @@ int _glfwPlatformGetPhysicalDevicePresentationSupport(VkInstance instance,
     {
         PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR
             vkGetPhysicalDeviceXcbPresentationSupportKHR =
-            (PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)
-            vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXcbPresentationSupportKHR");
+                (PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)
+                    vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXcbPresentationSupportKHR");
         if (!vkGetPhysicalDeviceXcbPresentationSupportKHR)
         {
             _glfwInputError(GLFW_API_UNAVAILABLE,
@@ -3162,7 +3234,7 @@ int _glfwPlatformGetPhysicalDevicePresentationSupport(VkInstance instance,
             return GLFW_FALSE;
         }
 
-        xcb_connection_t* connection = XGetXCBConnection(_glfw.x11.display);
+        xcb_connection_t *connection = XGetXCBConnection(_glfw.x11.display);
         if (!connection)
         {
             _glfwInputError(GLFW_PLATFORM_ERROR,
@@ -3179,8 +3251,8 @@ int _glfwPlatformGetPhysicalDevicePresentationSupport(VkInstance instance,
     {
         PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR
             vkGetPhysicalDeviceXlibPresentationSupportKHR =
-            (PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR)
-            vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXlibPresentationSupportKHR");
+                (PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR)
+                    vkGetInstanceProcAddr(instance, "vkGetPhysicalDeviceXlibPresentationSupportKHR");
         if (!vkGetPhysicalDeviceXlibPresentationSupportKHR)
         {
             _glfwInputError(GLFW_API_UNAVAILABLE,
@@ -3196,9 +3268,9 @@ int _glfwPlatformGetPhysicalDevicePresentationSupport(VkInstance instance,
 }
 
 VkResult _glfwPlatformCreateWindowSurface(VkInstance instance,
-                                          _GLFWwindow* window,
-                                          const VkAllocationCallbacks* allocator,
-                                          VkSurfaceKHR* surface)
+                                          _GLFWwindow *window,
+                                          const VkAllocationCallbacks *allocator,
+                                          VkSurfaceKHR *surface)
 {
     if (_glfw.vk.KHR_xcb_surface && _glfw.x11.x11xcb.handle)
     {
@@ -3206,7 +3278,7 @@ VkResult _glfwPlatformCreateWindowSurface(VkInstance instance,
         VkXcbSurfaceCreateInfoKHR sci;
         PFN_vkCreateXcbSurfaceKHR vkCreateXcbSurfaceKHR;
 
-        xcb_connection_t* connection = XGetXCBConnection(_glfw.x11.display);
+        xcb_connection_t *connection = XGetXCBConnection(_glfw.x11.display);
         if (!connection)
         {
             _glfwInputError(GLFW_PLATFORM_ERROR,
@@ -3270,7 +3342,7 @@ VkResult _glfwPlatformCreateWindowSurface(VkInstance instance,
     }
 }
 
-_GLFWusercontext* _glfwPlatformCreateUserContext(_GLFWwindow* window)
+_GLFWusercontext *_glfwPlatformCreateUserContext(_GLFWwindow *window)
 {
     if (window->context.glx.handle)
     {
@@ -3288,25 +3360,24 @@ _GLFWusercontext* _glfwPlatformCreateUserContext(_GLFWwindow* window)
     return GLFW_FALSE;
 }
 
-
 //////////////////////////////////////////////////////////////////////////
 //////                        GLFW native API                       //////
 //////////////////////////////////////////////////////////////////////////
 
-GLFWAPI Display* glfwGetX11Display(void)
+GLFWAPI Display *glfwGetX11Display(void)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     return _glfw.x11.display;
 }
 
-GLFWAPI Window glfwGetX11Window(GLFWwindow* handle)
+GLFWAPI Window glfwGetX11Window(GLFWwindow *handle)
 {
-    _GLFWwindow* window = (_GLFWwindow*) handle;
+    _GLFWwindow *window = (_GLFWwindow *)handle;
     _GLFW_REQUIRE_INIT_OR_RETURN(None);
     return window->x11.handle;
 }
 
-GLFWAPI void glfwSetX11SelectionString(const char* string)
+GLFWAPI void glfwSetX11SelectionString(const char *string)
 {
     _GLFW_REQUIRE_INIT();
 
@@ -3326,9 +3397,8 @@ GLFWAPI void glfwSetX11SelectionString(const char* string)
     }
 }
 
-GLFWAPI const char* glfwGetX11SelectionString(void)
+GLFWAPI const char *glfwGetX11SelectionString(void)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     return getSelectionString(_glfw.x11.PRIMARY);
 }
-


### PR DESCRIPTION
Added additional window hints so that https://github.com/Almamu/linux-wallpaperengine can do the following:

- be run as a background/desktop window 
- hidden from the taskbar 
- hidden from the pager 
- make the window sticky so it stays in place when swapping virtual desktops

```
    // TODO: FIGURE OUT HOW TO PUT THIS WINDOW IN THE BACKGROUND
    glfwWindowHint(GLFW_DECORATED, 0);
    glfwWindowHint(GLFW_NET_WM_WINDOW_TYPE_DESKTOP, 1);
    glfwWindowHint(GLFW_STICKY_WINDOW, 1);
    glfwWindowHint(GLFW_BELOW, 1);
    glfwWindowHint(GLFW_SKIP_TASKBAR, 1);
    glfwWindowHint(GLFW_SKIP_PAGER, 1);

    GLFWwindow *window = glfwCreateWindow(2560, 1440, "WallpaperEngine", NULL, NULL);
```